### PR TITLE
이미 진행중인 배틀에 존재하는 러너가 새로운 배틀을 생성할 수 없도록 수정한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
-public class BattleRestController {
+public class BattleController {
 
     BattleService battleService;
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
@@ -18,7 +18,7 @@ public class Battle {
     @Id String id;
 
     List<Runner> runners;
-
+    BattleStatus status = BattleStatus.RUNNING;
     @CreatedDate LocalDateTime createdAt;
 
     public Battle(List<Runner> runners) {

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleStatus.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleStatus.java
@@ -1,5 +1,6 @@
 package online.partyrun.partyrunbattleservice.domain.battle.entity;
 
 public enum BattleStatus {
-    RUNNING, FINISHED
+    RUNNING,
+    FINISHED
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleStatus.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleStatus.java
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunbattleservice.domain.battle.entity;
+
+public enum BattleStatus {
+    RUNNING, FINISHED
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/RunnerAlreadyRunningInBattleException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/RunnerAlreadyRunningInBattleException.java
@@ -1,0 +1,13 @@
+package online.partyrun.partyrunbattleservice.domain.battle.exception;
+
+import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
+import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
+
+import java.util.List;
+
+public class RunnerAlreadyRunningInBattleException extends BadRequestException {
+    public RunnerAlreadyRunningInBattleException(List<Runner> runners, List<Battle> runningBattle) {
+        super(String.format("이미 달리고 있는 %s 에 %s가 존재합니다.", runningBattle, runners));
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -2,6 +2,13 @@ package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 
+import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
+import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
-public interface BattleRepository extends MongoRepository<Battle, String> {}
+import java.util.List;
+
+public interface BattleRepository extends MongoRepository<Battle, String> {
+    List<Battle> findByStatusAndRunnersIn(BattleStatus status, List<Runner> runners);
+
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -1,14 +1,13 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
-
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.List;
 
 public interface BattleRepository extends MongoRepository<Battle, String> {
     List<Battle> findByStatusAndRunnersIn(BattleStatus status, List<Runner> runners);
-
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -8,6 +8,8 @@ import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateReque
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleMapper;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
+import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
+import online.partyrun.partyrunbattleservice.domain.battle.exception.RunnerAlreadyRunningInBattleException;
 import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.service.RunnerService;
@@ -29,8 +31,16 @@ public class BattleService {
         final List<String> runnerIds = request.getRunnerIds();
         final List<Runner> runners = runnerService.findAllById(runnerIds);
 
-        final Battle battle = battleRepository.save(new Battle(runners));
+        validateRunnerInRunningBattle(runners);
 
+        final Battle battle = battleRepository.save(new Battle(runners));
         return battleMapper.toResponse(battle);
+    }
+
+    private void validateRunnerInRunningBattle(List<Runner> runners) {
+        final List<Battle> runningBattle = battleRepository.findByStatusAndRunnersIn(BattleStatus.RUNNING, runners);
+        if (!runningBattle.isEmpty()) {
+            throw new RunnerAlreadyRunningInBattleException(runners, runningBattle);
+        }
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -38,7 +38,8 @@ public class BattleService {
     }
 
     private void validateRunnerInRunningBattle(List<Runner> runners) {
-        final List<Battle> runningBattle = battleRepository.findByStatusAndRunnersIn(BattleStatus.RUNNING, runners);
+        final List<Battle> runningBattle =
+                battleRepository.findByStatusAndRunnersIn(BattleStatus.RUNNING, runners);
         if (!runningBattle.isEmpty()) {
             throw new RunnerAlreadyRunningInBattleException(runners, runningBattle);
         }

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/config/MongoConfig.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/config/MongoConfig.java
@@ -1,0 +1,11 @@
+package online.partyrun.partyrunbattleservice.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@Configuration
+@EnableMongoAuditing
+@EnableMongoRepositories("online.partyrun.partyrunbattleservice")
+public class MongoConfig {
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/config/MongoConfig.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/config/MongoConfig.java
@@ -7,5 +7,4 @@ import org.springframework.data.mongodb.repository.config.EnableMongoRepositorie
 @Configuration
 @EnableMongoAuditing
 @EnableMongoRepositories("online.partyrun.partyrunbattleservice")
-public class MongoConfig {
-}
+public class MongoConfig {}

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.stream.Stream;
 
 @DisplayName("BattleRestController")
-class BattleRestControllerTest extends RestControllerNoneAuthTest {
+class BattleControllerTest extends RestControllerNoneAuthTest {
 
     @MockBean BattleService battleService;
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,0 +1,53 @@
+package online.partyrun.partyrunbattleservice.domain.battle.repository;
+
+import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
+import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
+import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataMongoTest
+@DisplayName("BattleRepository")
+class BattleRepositoryTest {
+
+    @Autowired
+    private RunnerRepository runnerRepository;
+
+    @Autowired
+    private BattleRepository battleRepository;
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 러너들이_존재할_때 {
+
+        Runner 박성우 = runnerRepository.save(new Runner("박성우"));
+        Runner 박현준 = runnerRepository.save(new Runner("박현준"));
+        Runner 노준혁 = runnerRepository.save(new Runner("노준혁"));
+
+        @Test
+        @DisplayName("현재 참여중인 배틀이 없으면 빈 리스트를 반환한다.")
+        void returnEmpty() {
+            final List<Battle> actual = battleRepository.findByStatusAndRunnersIn(BattleStatus.RUNNING, List.of(박성우, 박현준, 노준혁));
+            assertThat(actual).isEmpty();
+        }
+
+        @Test
+        @DisplayName("현재 참여중인 배틀이 있으면 참여한 배틀 리스트를 반환한다.")
+        void returnListBattle() {
+            final Battle battle1 = battleRepository.save(new Battle(List.of(박성우, 박현준)));
+            final Battle battle2 = battleRepository.save(new Battle(List.of(노준혁)));
+
+            final List<Battle> actual = battleRepository.findByStatusAndRunnersIn(BattleStatus.RUNNING, List.of(박성우, 박현준, 노준혁));
+
+            assertThat(actual)
+                    .usingRecursiveComparison()
+                    .isEqualTo(List.of(battle1, battle2));
+        }
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,26 +1,25 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @DataMongoTest
 @DisplayName("BattleRepository")
 class BattleRepositoryTest {
 
-    @Autowired
-    private RunnerRepository runnerRepository;
+    @Autowired private RunnerRepository runnerRepository;
 
-    @Autowired
-    private BattleRepository battleRepository;
+    @Autowired private BattleRepository battleRepository;
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -33,7 +32,9 @@ class BattleRepositoryTest {
         @Test
         @DisplayName("현재 참여중인 배틀이 없으면 빈 리스트를 반환한다.")
         void returnEmpty() {
-            final List<Battle> actual = battleRepository.findByStatusAndRunnersIn(BattleStatus.RUNNING, List.of(박성우, 박현준, 노준혁));
+            final List<Battle> actual =
+                    battleRepository.findByStatusAndRunnersIn(
+                            BattleStatus.RUNNING, List.of(박성우, 박현준, 노준혁));
             assertThat(actual).isEmpty();
         }
 
@@ -43,11 +44,11 @@ class BattleRepositoryTest {
             final Battle battle1 = battleRepository.save(new Battle(List.of(박성우, 박현준)));
             final Battle battle2 = battleRepository.save(new Battle(List.of(노준혁)));
 
-            final List<Battle> actual = battleRepository.findByStatusAndRunnersIn(BattleStatus.RUNNING, List.of(박성우, 박현준, 노준혁));
+            final List<Battle> actual =
+                    battleRepository.findByStatusAndRunnersIn(
+                            BattleStatus.RUNNING, List.of(박성우, 박현준, 노준혁));
 
-            assertThat(actual)
-                    .usingRecursiveComparison()
-                    .isEqualTo(List.of(battle1, battle2));
+            assertThat(actual).usingRecursiveComparison().isEqualTo(List.of(battle1, battle2));
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,17 +1,21 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
+import online.partyrun.partyrunbattleservice.domain.battle.exception.RunnerAlreadyRunningInBattleException;
 import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.service.RunnerService;
 
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.mongodb.core.MongoTemplate;
 
 import java.util.List;
 
@@ -19,23 +23,55 @@ import java.util.List;
 @DisplayName("BattleService")
 class BattleServiceTest {
 
-    @Autowired BattleService battleService;
+    @Autowired
+    BattleService battleService;
 
-    @MockBean RunnerService runnerService;
+    @Autowired
+    RunnerRepository runnerRepository;
+
+    @Autowired
+    MongoTemplate mongoTemplate;
+
+    @AfterEach
+    void setUp() {
+        mongoTemplate.getDb().drop();
+    }
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 배틀에_참가하는_러너들의_id가_주어지면 {
-        BattleCreateRequest request = new BattleCreateRequest(List.of("1", "2", "3"));
+        Runner 박성우 = runnerRepository.save(new Runner("박성우"));
+        Runner 박현준 = runnerRepository.save(new Runner("박현준"));
+        Runner 노준혁 = runnerRepository.save(new Runner("노준혁"));
+
+        BattleCreateRequest request = new BattleCreateRequest(List.of(박성우.getId(), 박현준.getId(), 노준혁.getId()));
 
         @Test
-        @DisplayName("생성된 방의 정보를 반환한다.")
+        @DisplayName("현재 배틀에 참여하는 러너가 없다면, 생성된 배틀의 정보를 반환한다.")
         void returnBattle() {
-            given(runnerService.findAllById(request.getRunnerIds()))
-                    .willReturn(List.of(new Runner("1"), new Runner("2"), new Runner("3")));
-
             final BattleResponse response = battleService.createBattle(request);
             assertThat(response.id()).isNotNull();
+        }
+
+        @Test
+        @DisplayName("러너들이 현재 다른 배틀에 모두 참여하고 있다면, 예외를 던진다.")
+        void throwExceptionsByAllRunner() {
+            battleService.createBattle(request);
+
+            assertThatThrownBy(() -> battleService.createBattle(request))
+                    .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
+        }
+
+        @Test
+        @DisplayName("한명이라도 다른 배틀에 참여하고 있는 러너가 있다면, 예외를 던진다.")
+        void throwExceptionsByOneRunner() {
+            Runner 장세연 = runnerRepository.save(new Runner("장세연"));
+            Runner 이승열 = runnerRepository.save(new Runner("이승열"));
+
+            battleService.createBattle(request);
+
+            assertThatThrownBy(() -> battleService.createBattle(new BattleCreateRequest(List.of(박성우.getId(), 장세연.getId(), 이승열.getId()))))
+                    .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -2,19 +2,16 @@ package online.partyrun.partyrunbattleservice.domain.battle.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
 
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.RunnerAlreadyRunningInBattleException;
 import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
-import online.partyrun.partyrunbattleservice.domain.runner.service.RunnerService;
 
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 import java.util.List;
@@ -23,14 +20,11 @@ import java.util.List;
 @DisplayName("BattleService")
 class BattleServiceTest {
 
-    @Autowired
-    BattleService battleService;
+    @Autowired BattleService battleService;
 
-    @Autowired
-    RunnerRepository runnerRepository;
+    @Autowired RunnerRepository runnerRepository;
 
-    @Autowired
-    MongoTemplate mongoTemplate;
+    @Autowired MongoTemplate mongoTemplate;
 
     @AfterEach
     void setUp() {
@@ -44,7 +38,8 @@ class BattleServiceTest {
         Runner 박현준 = runnerRepository.save(new Runner("박현준"));
         Runner 노준혁 = runnerRepository.save(new Runner("노준혁"));
 
-        BattleCreateRequest request = new BattleCreateRequest(List.of(박성우.getId(), 박현준.getId(), 노준혁.getId()));
+        BattleCreateRequest request =
+                new BattleCreateRequest(List.of(박성우.getId(), 박현준.getId(), 노준혁.getId()));
 
         @Test
         @DisplayName("현재 배틀에 참여하는 러너가 없다면, 생성된 배틀의 정보를 반환한다.")
@@ -70,7 +65,14 @@ class BattleServiceTest {
 
             battleService.createBattle(request);
 
-            assertThatThrownBy(() -> battleService.createBattle(new BattleCreateRequest(List.of(박성우.getId(), 장세연.getId(), 이승열.getId()))))
+            assertThatThrownBy(
+                            () ->
+                                    battleService.createBattle(
+                                            new BattleCreateRequest(
+                                                    List.of(
+                                                            박성우.getId(),
+                                                            장세연.getId(),
+                                                            이승열.getId()))))
                     .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
         }
     }


### PR DESCRIPTION
## 변경 사항
배틀을 생성할 때 이미 진행중인 배틀에 존재하는 러너가 새로운 배틀에 참여하게되면 안되기 때문에, 예외를 던지도록 수정했습니다.

이 과정을 위해서 Battle에 상태(Status)가 들어갑니다.


## 알아야할 사항
mongoRepository를 이용하여 findByStatusAndRunnersIn (이름으로 쿼리 생성) 을 만들었습니다.