### PR TITLE
클라이언트에게 배틀 정보를 전달한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
 
     testImplementation 'com.github.SWM-KAWAI-MANS:test-manager:1.0.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'com.github.SWM-KAWAI-MANS:spring-security-authorization-manager:1.0.0'
 
     //mapstruct
     implementation 'org.mapstruct:mapstruct:1.5.1.Final'

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-security'
-    implementation 'com.github.SWM-KAWAI-MANS:spring-security-authorization-manager:1.0.0'
+    implementation 'com.github.SWM-KAWAI-MANS:spring-security-authorization-manager:1.0.1'
 
     //mapstruct
     implementation 'org.mapstruct:mapstruct:1.5.1.Final'
@@ -70,6 +70,8 @@ dependencies {
     testImplementation 'com.github.SWM-KAWAI-MANS:test-manager:1.0.0'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    testImplementation 'io.rest-assured:rest-assured:5.3.1'
+    testImplementation 'com.github.SWM-KAWAI-MANS:jwt-manager:1.2.0'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -15,4 +15,5 @@ operation::runner request is invalid, runner is null[snippets='http-request,http
 
 === 배틀 조회
 operation::get battle[snippets='http-request,http-response']
+operation::battle not found[snippets='http-request,http-response']
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -5,15 +5,32 @@
 :toclevels: 4
 :sectlinks:
 
-== Battle
-=== 배틀 생성
+= Battle
+== 배틀 생성
 operation::create battle[snippets='http-request,http-response']
-=== 배틀 생성 인원 부족 실패
+
+=== 배틀 생성 실패
+body가 null일 때
+
 operation::runner request is invalid, body is null[snippets='http-request,http-response']
+---
+
+number of runners error
+
 operation::runner request is invalid, number of runners error[snippets='http-request,http-response']
+---
+
+runner is null
+
 operation::runner request is invalid, runner is null[snippets='http-request,http-response']
+---
 
 === 배틀 조회
 operation::get battle[snippets='http-request,http-response']
+---
+
+=== 배틀 조회 실패
+현재 배틀을 진행하고 있지 않은 러너가 조회요청을 했을 때
+
 operation::battle not found[snippets='http-request,http-response']
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -6,10 +6,13 @@
 :sectlinks:
 
 == Battle
-=== 방 생성
+=== 배틀 생성
 operation::create battle[snippets='http-request,http-response']
-=== 방 생성 인원 부족 실패
+=== 배틀 생성 인원 부족 실패
 operation::runner request is invalid, body is null[snippets='http-request,http-response']
 operation::runner request is invalid, number of runners error[snippets='http-request,http-response']
 operation::runner request is invalid, runner is null[snippets='http-request,http-response']
+
+=== 배틀 조회
+operation::get battle[snippets='http-request,http-response']
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
@@ -16,19 +16,20 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("battle")
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class BattleController {
 
     BattleService battleService;
 
-    @PostMapping("battle")
+    @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public BattleResponse createBattle(@RequestBody @Valid BattleCreateRequest request) {
 
         return battleService.createBattle(request);
     }
 
-    @GetMapping("battle/running")
+    @GetMapping("running")
     @ResponseStatus(HttpStatus.OK)
     public BattleResponse getRunningBattle(Authentication auth) {
         return battleService.getRunningBattle(auth.getName());

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
@@ -11,10 +11,8 @@ import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -28,5 +26,13 @@ public class BattleController {
     public BattleResponse createBattle(@RequestBody @Valid BattleCreateRequest request) {
 
         return battleService.createBattle(request);
+    }
+
+    @GetMapping("battle/running")
+    @ResponseStatus(HttpStatus.OK)
+    public BattleResponse getRunningBattle(Authentication auth) {
+        final String runnerId = (String) auth.getPrincipal();
+
+        return battleService.getRunningBattle(runnerId);
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
@@ -31,8 +31,6 @@ public class BattleController {
     @GetMapping("battle/running")
     @ResponseStatus(HttpStatus.OK)
     public BattleResponse getRunningBattle(Authentication auth) {
-        final String runnerId = (String) auth.getPrincipal();
-
-        return battleService.getRunningBattle(runnerId);
+        return battleService.getRunningBattle(auth.getName());
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/RunningBattleNotFoundException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/RunningBattleNotFoundException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunbattleservice.domain.battle.exception;
+
+import online.partyrun.partyrunbattleservice.global.exception.NotFoundException;
+
+public class RunningBattleNotFoundException extends NotFoundException {
+    public RunningBattleNotFoundException(String runnerId) {
+        super(String.format("%s는 현재 진행중인 battle에 참여하고 있지 않습니다.", runnerId));
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -7,7 +7,10 @@ import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface BattleRepository extends MongoRepository<Battle, String> {
     List<Battle> findByStatusAndRunnersIn(BattleStatus status, List<Runner> runners);
+
+    Optional<Battle> findByStatusAndRunnersId(BattleStatus status, String runnersId);
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -47,8 +47,10 @@ public class BattleService {
     }
 
     public BattleResponse getRunningBattle(String runnerId) {
-        final Battle battle = battleRepository.findByStatusAndRunnersId(BattleStatus.RUNNING, runnerId)
-                .orElseThrow(() -> new RunningBattleNotFoundException(runnerId));
+        final Battle battle =
+                battleRepository
+                        .findByStatusAndRunnersId(BattleStatus.RUNNING, runnerId)
+                        .orElseThrow(() -> new RunningBattleNotFoundException(runnerId));
 
         return battleMapper.toResponse(battle);
     }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -10,6 +10,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.RunnerAlreadyRunningInBattleException;
+import online.partyrun.partyrunbattleservice.domain.battle.exception.RunningBattleNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.service.RunnerService;
@@ -43,5 +44,12 @@ public class BattleService {
         if (!runningBattle.isEmpty()) {
             throw new RunnerAlreadyRunningInBattleException(runners, runningBattle);
         }
+    }
+
+    public BattleResponse getRunningBattle(String runnerId) {
+        final Battle battle = battleRepository.findByStatusAndRunnersId(BattleStatus.RUNNING, runnerId)
+                .orElseThrow(() -> new RunningBattleNotFoundException(runnerId));
+
+        return battleMapper.toResponse(battle);
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
@@ -1,0 +1,18 @@
+package online.partyrun.partyrunbattleservice.global.config;
+
+import lombok.extern.slf4j.Slf4j;
+import online.partyrun.springsecurityauthorizationmanager.AuthorizationRegistry;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class BattleAuthorizationRegistry implements AuthorizationRegistry {
+
+    @Override
+    public AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry match(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry r) {
+        return r.requestMatchers("/battle").permitAll()
+                .anyRequest().hasRole("USER");
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
@@ -1,14 +1,10 @@
 package online.partyrun.partyrunbattleservice.global.config;
 
-import lombok.extern.slf4j.Slf4j;
-
 import online.partyrun.springsecurityauthorizationmanager.AuthorizationRegistry;
-
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 public class BattleAuthorizationRegistry implements AuthorizationRegistry {
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
@@ -14,6 +14,6 @@ public class BattleAuthorizationRegistry implements AuthorizationRegistry {
                     AuthorizeHttpRequestsConfigurer<HttpSecurity>
                                     .AuthorizationManagerRequestMatcherRegistry
                             r) {
-        return r.requestMatchers("/battle").permitAll().anyRequest().hasRole("USER");
+        return r.requestMatchers("/battle").hasRole("SYSTEM").anyRequest().hasRole("USER");
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
@@ -1,7 +1,9 @@
 package online.partyrun.partyrunbattleservice.global.config;
 
 import lombok.extern.slf4j.Slf4j;
+
 import online.partyrun.springsecurityauthorizationmanager.AuthorizationRegistry;
+
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.stereotype.Component;
@@ -11,8 +13,11 @@ import org.springframework.stereotype.Component;
 public class BattleAuthorizationRegistry implements AuthorizationRegistry {
 
     @Override
-    public AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry match(AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry r) {
-        return r.requestMatchers("/battle").permitAll()
-                .anyRequest().hasRole("USER");
+    public AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry
+            match(
+                    AuthorizeHttpRequestsConfigurer<HttpSecurity>
+                                    .AuthorizationManagerRequestMatcherRegistry
+                            r) {
+        return r.requestMatchers("/battle").permitAll().anyRequest().hasRole("USER");
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
@@ -1,6 +1,7 @@
 package online.partyrun.partyrunbattleservice.global.config;
 
 import online.partyrun.springsecurityauthorizationmanager.AuthorizationRegistry;
+
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer;
 import org.springframework.stereotype.Component;

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/controller/HttpControllerAdvice.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/controller/HttpControllerAdvice.java
@@ -3,9 +3,8 @@ package online.partyrun.partyrunbattleservice.global.controller;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
-
 import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
-
+import online.partyrun.partyrunbattleservice.global.exception.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -23,12 +22,13 @@ import java.util.stream.Collectors;
 public class HttpControllerAdvice {
 
     static String BAD_REQUEST_MESSAGE = "잘못된 요청입니다.";
+    static String NOT_FOUND_EXCEPTION_MESSAGE = "요청한 리소스를 찾을 수 없습니다.";
     static String SERVER_ERROR_MESSAGE = "알 수 없는 에러입니다.";
 
     @ExceptionHandler({
-        BadRequestException.class,
-        HttpMessageNotReadableException.class,
-        MissingRequestHeaderException.class
+            BadRequestException.class,
+            HttpMessageNotReadableException.class,
+            MissingRequestHeaderException.class
     })
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionResponse handleBadRequestException(BadRequestException exception) {
@@ -51,6 +51,13 @@ public class HttpControllerAdvice {
 
         log.warn(message);
         return new ExceptionResponse(BAD_REQUEST_MESSAGE);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    @ResponseStatus(HttpStatus.NOT_FOUND)
+    public ExceptionResponse handleNotFoundException(NotFoundException exception) {
+        log.warn(exception.getMessage());
+        return new ExceptionResponse(NOT_FOUND_EXCEPTION_MESSAGE);
     }
 
     @ExceptionHandler({RuntimeException.class, Exception.class})

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/controller/HttpControllerAdvice.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/controller/HttpControllerAdvice.java
@@ -3,8 +3,10 @@ package online.partyrun.partyrunbattleservice.global.controller;
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+
 import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
 import online.partyrun.partyrunbattleservice.global.exception.NotFoundException;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -26,9 +28,9 @@ public class HttpControllerAdvice {
     static String SERVER_ERROR_MESSAGE = "알 수 없는 에러입니다.";
 
     @ExceptionHandler({
-            BadRequestException.class,
-            HttpMessageNotReadableException.class,
-            MissingRequestHeaderException.class
+        BadRequestException.class,
+        HttpMessageNotReadableException.class,
+        MissingRequestHeaderException.class
     })
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     public ExceptionResponse handleBadRequestException(BadRequestException exception) {

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/exception/BadRequestException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/exception/BadRequestException.java
@@ -1,11 +1,11 @@
 package online.partyrun.partyrunbattleservice.global.exception;
 
-public class BadRequestException extends RuntimeException {
-    public BadRequestException() {
+public abstract class BadRequestException extends RuntimeException {
+    protected BadRequestException() {
         super("잘못된 요청입니다.");
     }
 
-    public BadRequestException(String message) {
+    protected BadRequestException(String message) {
         super(message);
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/exception/NotFoundException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/exception/NotFoundException.java
@@ -1,0 +1,11 @@
+package online.partyrun.partyrunbattleservice.global.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException() {
+        super("요청한 리소스를 찾을 수 없습니다.");
+    }
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/exception/NotFoundException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/exception/NotFoundException.java
@@ -1,11 +1,11 @@
 package online.partyrun.partyrunbattleservice.global.exception;
 
-public class NotFoundException extends RuntimeException {
-    public NotFoundException() {
+public abstract class NotFoundException extends RuntimeException {
+    protected NotFoundException() {
         super("요청한 리소스를 찾을 수 없습니다.");
     }
 
-    public NotFoundException(String message) {
+    protected NotFoundException(String message) {
         super(message);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,9 +1,6 @@
 server:
   servlet:
     context-path: /api
-auth:
-  filter:
-    exclusions: "battle"
 
 spring:
   profiles:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 server:
   servlet:
     context-path: /api
+auth:
+  filter:
+    exclusions: "battle"
 
 spring:
   profiles:

--- a/src/test/java/online/partyrun/partyrunbattleservice/acceptance/AcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/acceptance/AcceptanceTest.java
@@ -1,6 +1,7 @@
 package online.partyrun.partyrunbattleservice.acceptance;
 
 import io.restassured.RestAssured;
+
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,16 +12,14 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AcceptanceTest {
 
-    @LocalServerPort
-    private int port;
+    @LocalServerPort private int port;
 
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
     }
 
-    @Autowired
-    private MongoTemplate mongoTemplate;
+    @Autowired private MongoTemplate mongoTemplate;
 
     @AfterEach
     public void tearDown() {

--- a/src/test/java/online/partyrun/partyrunbattleservice/acceptance/AcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/acceptance/AcceptanceTest.java
@@ -1,0 +1,29 @@
+package online.partyrun.partyrunbattleservice.acceptance;
+
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class AcceptanceTest {
+
+    @LocalServerPort
+    private int port;
+
+    @BeforeEach
+    public void setUp() {
+        RestAssured.port = port;
+    }
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
+
+    @AfterEach
+    public void tearDown() {
+        mongoTemplate.getDb().drop();
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/acceptance/AcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/acceptance/AcceptanceTest.java
@@ -10,7 +10,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class AcceptanceTest {
+public abstract class AcceptanceTest {
 
     @LocalServerPort private int port;
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/acceptance/SimpleRestAssured.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/acceptance/SimpleRestAssured.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
+
 import org.springframework.http.MediaType;
 
 import java.util.Map;
@@ -17,7 +18,8 @@ public class SimpleRestAssured {
         return post(path, null, request);
     }
 
-    public static ExtractableResponse<Response> post(String path, Map<String, String> headers, Object request) {
+    public static ExtractableResponse<Response> post(
+            String path, Map<String, String> headers, Object request) {
         final RequestSpecification given = givenWithHeaders(headers);
         if (request != null) {
             given.body(request);

--- a/src/test/java/online/partyrun/partyrunbattleservice/acceptance/SimpleRestAssured.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/acceptance/SimpleRestAssured.java
@@ -1,0 +1,48 @@
+package online.partyrun.partyrunbattleservice.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.springframework.http.MediaType;
+
+import java.util.Map;
+
+public class SimpleRestAssured {
+    public static ExtractableResponse<Response> get(String path, Map<String, String> headers) {
+        return thenExtract(givenWithHeaders(headers).when().get(path));
+    }
+
+    public static ExtractableResponse<Response> post(String path, Object request) {
+        return post(path, null, request);
+    }
+
+    public static ExtractableResponse<Response> post(String path, Map<String, String> headers, Object request) {
+        final RequestSpecification given = givenWithHeaders(headers);
+        if (request != null) {
+            given.body(request);
+        }
+
+        return thenExtract(given.contentType(MediaType.APPLICATION_JSON_VALUE).when().post(path));
+    }
+
+    private static ExtractableResponse<Response> thenExtract(Response response) {
+        return response.then().log().all().extract();
+    }
+
+    public static <T> T toObject(ExtractableResponse<Response> response, Class<T> clazz) {
+        return response.as(clazz);
+    }
+
+    private static RequestSpecification givenWithHeaders(Map<String, String> headers) {
+        final RequestSpecification given = given();
+        if (headers != null) {
+            given.headers(headers);
+        }
+        return given;
+    }
+
+    private static RequestSpecification given() {
+        return RestAssured.given().log().all();
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleAcceptanceTest.java
@@ -1,13 +1,22 @@
 package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
+import static online.partyrun.partyrunbattleservice.acceptance.SimpleRestAssured.toObject;
+import static online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest.BattleRestAssuredRequest.배틀_생성_요청;
+import static online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest.BattleRestAssuredRequest.배틀_조회_요청;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -15,20 +24,12 @@ import org.springframework.http.HttpStatus;
 import java.util.List;
 import java.util.Set;
 
-import static online.partyrun.partyrunbattleservice.acceptance.SimpleRestAssured.toObject;
-import static online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest.BattleRestAssuredRequest.배틀_생성_요청;
-import static online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest.BattleRestAssuredRequest.배틀_조회_요청;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 @DisplayName("BattleAcceptanceTest")
 public class BattleAcceptanceTest extends AcceptanceTest {
 
-    @Autowired
-    RunnerRepository runnerRepository;
+    @Autowired RunnerRepository runnerRepository;
 
-    @Autowired
-    JwtGenerator jwtGenerator;
+    @Autowired JwtGenerator jwtGenerator;
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -44,11 +45,17 @@ public class BattleAcceptanceTest extends AcceptanceTest {
             @Test
             @DisplayName("Create와 방 생성 정보를 응답한다.")
             void returnCreated() {
-                final ExtractableResponse<Response> response = 배틀_생성_요청(new BattleCreateRequest(List.of(박성우.getId(), 노준혁.getId(), 박현준.getId())));
+                final ExtractableResponse<Response> response =
+                        배틀_생성_요청(
+                                new BattleCreateRequest(
+                                        List.of(박성우.getId(), 노준혁.getId(), 박현준.getId())));
                 assertAll(
-                        () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
-                        () -> assertThat(toObject(response, BattleResponse.class).id()).isNotNull()
-                );
+                        () ->
+                                assertThat(response.statusCode())
+                                        .isEqualTo(HttpStatus.CREATED.value()),
+                        () ->
+                                assertThat(toObject(response, BattleResponse.class).id())
+                                        .isNotNull());
             }
         }
     }
@@ -59,7 +66,8 @@ public class BattleAcceptanceTest extends AcceptanceTest {
         Runner 박성우 = runnerRepository.save(new Runner("박성우"));
         Runner 노준혁 = runnerRepository.save(new Runner("노준혁"));
         Runner 박현준 = runnerRepository.save(new Runner("박현준"));
-        String 박성우_accessToken = jwtGenerator.generate(박성우.getId(), Set.of("ROLE_USER")).accessToken();
+        String 박성우_accessToken =
+                jwtGenerator.generate(박성우.getId(), Set.of("ROLE_USER")).accessToken();
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -73,8 +81,9 @@ public class BattleAcceptanceTest extends AcceptanceTest {
 
                 assertAll(
                         () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                        () -> assertThat(toObject(response, BattleResponse.class).id()).isNotNull()
-                );
+                        () ->
+                                assertThat(toObject(response, BattleResponse.class).id())
+                                        .isNotNull());
             }
         }
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleAcceptanceTest.java
@@ -30,6 +30,7 @@ public class BattleAcceptanceTest extends AcceptanceTest {
     @Autowired RunnerRepository runnerRepository;
 
     @Autowired JwtGenerator jwtGenerator;
+    private static final String SYSTEM_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJpZCI6Im1hdGNoaW5nIiwicm9sZSI6WyJST0xFX1NZU1RFTSJdLCJleHAiOjMxNTU3MzEyNjF9.IGEtuEEaRKD9k-1EcvG3GWfs9nFgkz2UScHphRB-EUmufwPEtPrLF26T4CNoYeD9cfArKqz1km2m0pXYzo-9UA";
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -47,6 +48,7 @@ public class BattleAcceptanceTest extends AcceptanceTest {
             void returnCreated() {
                 final ExtractableResponse<Response> response =
                         배틀_생성_요청(
+                                SYSTEM_TOKEN,
                                 new BattleCreateRequest(
                                         List.of(박성우.getId(), 노준혁.getId(), 박현준.getId())));
                 assertAll(
@@ -76,7 +78,7 @@ public class BattleAcceptanceTest extends AcceptanceTest {
             @Test
             @DisplayName("OK와 배틀 정보를 응답한다.")
             void returnOK() {
-                배틀_생성_요청(new BattleCreateRequest(List.of(박성우.getId(), 노준혁.getId(), 박현준.getId())));
+                배틀_생성_요청(SYSTEM_TOKEN, new BattleCreateRequest(List.of(박성우.getId(), 노준혁.getId(), 박현준.getId())));
                 final ExtractableResponse<Response> response = 배틀_조회_요청(박성우_accessToken);
 
                 assertAll(

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleAcceptanceTest.java
@@ -77,5 +77,18 @@ public class BattleAcceptanceTest extends AcceptanceTest {
                 );
             }
         }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 요청에_잘못된_토큰을_요청하면 {
+
+            @Test
+            @DisplayName("Forbidden을 반환한다.")
+            void returnBadRequest() {
+                final ExtractableResponse<Response> response = 배틀_조회_요청("invalidToken");
+
+                assertThat(response.statusCode()).isEqualTo(HttpStatus.FORBIDDEN.value());
+            }
+        }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleAcceptanceTest.java
@@ -30,7 +30,8 @@ public class BattleAcceptanceTest extends AcceptanceTest {
     @Autowired RunnerRepository runnerRepository;
 
     @Autowired JwtGenerator jwtGenerator;
-    private static final String SYSTEM_TOKEN = "eyJhbGciOiJIUzUxMiJ9.eyJpZCI6Im1hdGNoaW5nIiwicm9sZSI6WyJST0xFX1NZU1RFTSJdLCJleHAiOjMxNTU3MzEyNjF9.IGEtuEEaRKD9k-1EcvG3GWfs9nFgkz2UScHphRB-EUmufwPEtPrLF26T4CNoYeD9cfArKqz1km2m0pXYzo-9UA";
+    private static final String SYSTEM_TOKEN =
+            "eyJhbGciOiJIUzUxMiJ9.eyJpZCI6Im1hdGNoaW5nIiwicm9sZSI6WyJST0xFX1NZU1RFTSJdLCJleHAiOjMxNTU3MzEyNjF9.IGEtuEEaRKD9k-1EcvG3GWfs9nFgkz2UScHphRB-EUmufwPEtPrLF26T4CNoYeD9cfArKqz1km2m0pXYzo-9UA";
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -78,7 +79,9 @@ public class BattleAcceptanceTest extends AcceptanceTest {
             @Test
             @DisplayName("OK와 배틀 정보를 응답한다.")
             void returnOK() {
-                배틀_생성_요청(SYSTEM_TOKEN, new BattleCreateRequest(List.of(박성우.getId(), 노준혁.getId(), 박현준.getId())));
+                배틀_생성_요청(
+                        SYSTEM_TOKEN,
+                        new BattleCreateRequest(List.of(박성우.getId(), 노준혁.getId(), 박현준.getId())));
                 final ExtractableResponse<Response> response = 배틀_조회_요청(박성우_accessToken);
 
                 assertAll(

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleAcceptanceTest.java
@@ -1,0 +1,81 @@
+package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import online.partyrun.jwtmanager.JwtGenerator;
+import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
+import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
+import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
+import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+
+import java.util.List;
+import java.util.Set;
+
+import static online.partyrun.partyrunbattleservice.acceptance.SimpleRestAssured.toObject;
+import static online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest.BattleRestAssuredRequest.배틀_생성_요청;
+import static online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest.BattleRestAssuredRequest.배틀_조회_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@DisplayName("BattleAcceptanceTest")
+public class BattleAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    RunnerRepository runnerRepository;
+
+    @Autowired
+    JwtGenerator jwtGenerator;
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 배틀_생성을_할_때 {
+        Runner 박성우 = runnerRepository.save(new Runner("박성우"));
+        Runner 노준혁 = runnerRepository.save(new Runner("노준혁"));
+        Runner 박현준 = runnerRepository.save(new Runner("박현준"));
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 정상적인_러너들로_요청하면 {
+
+            @Test
+            @DisplayName("Create와 방 생성 정보를 응답한다.")
+            void returnCreated() {
+                final ExtractableResponse<Response> response = 배틀_생성_요청(new BattleCreateRequest(List.of(박성우.getId(), 노준혁.getId(), 박현준.getId())));
+                assertAll(
+                        () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value()),
+                        () -> assertThat(toObject(response, BattleResponse.class).id()).isNotNull()
+                );
+            }
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 배틀을_조회_할_때 {
+        Runner 박성우 = runnerRepository.save(new Runner("박성우"));
+        Runner 노준혁 = runnerRepository.save(new Runner("노준혁"));
+        Runner 박현준 = runnerRepository.save(new Runner("박현준"));
+        String 박성우_accessToken = jwtGenerator.generate(박성우.getId(), Set.of("ROLE_USER")).accessToken();
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 배틀에_참여하고_있는_러너가_요청하면 {
+
+            @Test
+            @DisplayName("OK와 배틀 정보를 응답한다.")
+            void returnOK() {
+                배틀_생성_요청(new BattleCreateRequest(List.of(박성우.getId(), 노준혁.getId(), 박현준.getId())));
+                final ExtractableResponse<Response> response = 배틀_조회_요청(박성우_accessToken);
+
+                assertAll(
+                        () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                        () -> assertThat(toObject(response, BattleResponse.class).id()).isNotNull()
+                );
+            }
+        }
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleRestAssuredRequest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleRestAssuredRequest.java
@@ -12,8 +12,8 @@ public class BattleRestAssuredRequest {
     private static final String PREFIX_URL = "api";
     private static final String BATTLE_URL = "battle";
 
-    public static final ExtractableResponse<Response> 배틀_생성_요청(BattleCreateRequest request) {
-        return SimpleRestAssured.post(String.format("/%s/%s", PREFIX_URL, BATTLE_URL), request);
+    public static final ExtractableResponse<Response> 배틀_생성_요청(String systemToken, BattleCreateRequest request) {
+        return SimpleRestAssured.post(String.format("/%s/%s", PREFIX_URL, BATTLE_URL), Map.of("Authorization", systemToken), request);
     }
 
     public static final ExtractableResponse<Response> 배틀_조회_요청(String accessToken) {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleRestAssuredRequest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleRestAssuredRequest.java
@@ -2,6 +2,7 @@ package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+
 import online.partyrun.partyrunbattleservice.acceptance.SimpleRestAssured;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 
@@ -10,11 +11,14 @@ import java.util.Map;
 public class BattleRestAssuredRequest {
     private static final String PREFIX_URL = "api";
     private static final String BATTLE_URL = "battle";
+
     public static final ExtractableResponse<Response> 배틀_생성_요청(BattleCreateRequest request) {
         return SimpleRestAssured.post(String.format("/%s/%s", PREFIX_URL, BATTLE_URL), request);
     }
 
     public static final ExtractableResponse<Response> 배틀_조회_요청(String accessToken) {
-        return SimpleRestAssured.get(String.format("/%s/%s/running", PREFIX_URL, BATTLE_URL), Map.of("Authorization", accessToken));
+        return SimpleRestAssured.get(
+                String.format("/%s/%s/running", PREFIX_URL, BATTLE_URL),
+                Map.of("Authorization", accessToken));
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleRestAssuredRequest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleRestAssuredRequest.java
@@ -12,8 +12,12 @@ public class BattleRestAssuredRequest {
     private static final String PREFIX_URL = "api";
     private static final String BATTLE_URL = "battle";
 
-    public static final ExtractableResponse<Response> 배틀_생성_요청(String systemToken, BattleCreateRequest request) {
-        return SimpleRestAssured.post(String.format("/%s/%s", PREFIX_URL, BATTLE_URL), Map.of("Authorization", systemToken), request);
+    public static final ExtractableResponse<Response> 배틀_생성_요청(
+            String systemToken, BattleCreateRequest request) {
+        return SimpleRestAssured.post(
+                String.format("/%s/%s", PREFIX_URL, BATTLE_URL),
+                Map.of("Authorization", systemToken),
+                request);
     }
 
     public static final ExtractableResponse<Response> 배틀_조회_요청(String accessToken) {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleRestAssuredRequest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleRestAssuredRequest.java
@@ -1,0 +1,20 @@
+package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import online.partyrun.partyrunbattleservice.acceptance.SimpleRestAssured;
+import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
+
+import java.util.Map;
+
+public class BattleRestAssuredRequest {
+    private static final String PREFIX_URL = "api";
+    private static final String BATTLE_URL = "battle";
+    public static final ExtractableResponse<Response> 배틀_생성_요청(BattleCreateRequest request) {
+        return SimpleRestAssured.post(String.format("/%s/%s", PREFIX_URL, BATTLE_URL), request);
+    }
+
+    public static final ExtractableResponse<Response> 배틀_조회_요청(String accessToken) {
+        return SimpleRestAssured.get(String.format("/%s/%s/running", PREFIX_URL, BATTLE_URL), Map.of("Authorization", accessToken));
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -29,55 +29,59 @@ class BattleControllerTest extends RestControllerNoneAuthTest {
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-    class 정상적인_러너들의_id가_주어졌을_때 {
+    class 배틀을_생성할_때 {
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 정상적인_러너들의_id가_주어지면 {
 
-        BattleCreateRequest request = new BattleCreateRequest(List.of("1", "2", "3"));
+            BattleCreateRequest request = new BattleCreateRequest(List.of("1", "2", "3"));
 
-        @Test
-        @DisplayName("방 생성을 수행한다")
-        void createBattle() throws Exception {
-            given(battleService.createBattle(request)).willReturn(new BattleResponse("battle_id"));
+            @Test
+            @DisplayName("배틀 생성을 수행한다")
+            void createBattle() throws Exception {
+                given(battleService.createBattle(request)).willReturn(new BattleResponse("battle_id"));
 
-            final ResultActions actions =
-                    mockMvc.perform(
-                            post("/battle")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .characterEncoding(StandardCharsets.UTF_8)
-                                    .content(toRequestBody(request)));
-            actions.andExpect(status().isCreated());
+                final ResultActions actions =
+                        mockMvc.perform(
+                                post("/battle")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .characterEncoding(StandardCharsets.UTF_8)
+                                        .content(toRequestBody(request)));
+                actions.andExpect(status().isCreated());
 
-            setPrintDocs(actions, "create battle");
-        }
-    }
-
-    @Nested
-    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-    class 러너_요청이_잘못되었을_때 {
-
-        public static Stream<Arguments> invalidBattleRequest() {
-            return Stream.of(
-                    Arguments.of(null, "body is null"),
-                    Arguments.of(
-                            new BattleCreateRequest(List.of("2", "3")), "number of runners error"),
-                    Arguments.of(new BattleCreateRequest(null), "runner is null"));
+                setPrintDocs(actions, "create battle");
+            }
         }
 
-        @ParameterizedTest
-        @MethodSource("invalidBattleRequest")
-        @DisplayName("BadRequest를 응답한다.")
-        void returnException(BattleCreateRequest invalidRequest, String message) throws Exception {
-            given(battleService.createBattle(invalidRequest))
-                    .willThrow(new InvalidNumberOfBattleRunnerException(2));
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 러너_요청이_잘못되었다면 {
 
-            final ResultActions actions =
-                    mockMvc.perform(
-                            post("/battle")
-                                    .contentType(MediaType.APPLICATION_JSON)
-                                    .characterEncoding(StandardCharsets.UTF_8)
-                                    .content(toRequestBody(invalidRequest)));
-            actions.andExpect(status().isBadRequest());
+            public static Stream<Arguments> invalidBattleRequest() {
+                return Stream.of(
+                        Arguments.of(null, "body is null"),
+                        Arguments.of(
+                                new BattleCreateRequest(List.of("2", "3")), "number of runners error"),
+                        Arguments.of(new BattleCreateRequest(null), "runner is null"));
+            }
 
-            setPrintDocs(actions, String.format("runner request is invalid, %s", message));
+            @ParameterizedTest
+            @MethodSource("invalidBattleRequest")
+            @DisplayName("BadRequest를 응답한다.")
+            void returnException(BattleCreateRequest invalidRequest, String message) throws Exception {
+                given(battleService.createBattle(invalidRequest))
+                        .willThrow(new InvalidNumberOfBattleRunnerException(2));
+
+                final ResultActions actions =
+                        mockMvc.perform(
+                                post("/battle")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .characterEncoding(StandardCharsets.UTF_8)
+                                        .content(toRequestBody(invalidRequest)));
+                actions.andExpect(status().isBadRequest());
+
+                setPrintDocs(actions, String.format("runner request is invalid, %s", message));
+            }
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,15 +1,10 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidNumberOfBattleRunnerException;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
-import online.partyrun.testmanager.docs.RestControllerNoneAuthTest;
-
+import online.partyrun.testmanager.docs.RestControllerTest;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -22,10 +17,17 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
 
-@DisplayName("BattleRestController")
-class BattleControllerTest extends RestControllerNoneAuthTest {
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-    @MockBean BattleService battleService;
+@DisplayName("BattleRestController")
+class BattleControllerTest extends RestControllerTest {
+
+    @MockBean
+    BattleService battleService;
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -43,7 +45,7 @@ class BattleControllerTest extends RestControllerNoneAuthTest {
 
                 final ResultActions actions =
                         mockMvc.perform(
-                                post("/battle")
+                                post("/battle").with(csrf())
                                         .contentType(MediaType.APPLICATION_JSON)
                                         .characterEncoding(StandardCharsets.UTF_8)
                                         .content(toRequestBody(request)));
@@ -74,13 +76,40 @@ class BattleControllerTest extends RestControllerNoneAuthTest {
 
                 final ResultActions actions =
                         mockMvc.perform(
-                                post("/battle")
+                                post("/battle").with(csrf())
                                         .contentType(MediaType.APPLICATION_JSON)
                                         .characterEncoding(StandardCharsets.UTF_8)
                                         .content(toRequestBody(invalidRequest)));
                 actions.andExpect(status().isBadRequest());
 
                 setPrintDocs(actions, String.format("runner request is invalid, %s", message));
+            }
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 배틀_조회를_요청할_때 {
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 배틀에_참여하고_있는_러너의_id가_주어지면 {
+
+            @Test
+            @DisplayName("배틀 정보를 반환한다.")
+            void getRunningBattle() throws Exception {
+                given(battleService.getRunningBattle("박현준")).willReturn(new BattleResponse("battle_id"));
+
+                final ResultActions actions =
+                        mockMvc.perform(
+                                get("/battle/running")
+                                        .header("Authorization", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .characterEncoding(StandardCharsets.UTF_8));
+
+                actions.andExpect(status().isOk());
+
+                setPrintDocs(actions, "get battle");
             }
         }
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,11 +1,19 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidNumberOfBattleRunnerException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.RunningBattleNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
 import online.partyrun.testmanager.docs.RestControllerTest;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -18,18 +26,10 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @DisplayName("BattleRestController")
 class BattleControllerTest extends RestControllerTest {
 
-    @MockBean
-    BattleService battleService;
+    @MockBean BattleService battleService;
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -48,7 +48,8 @@ class BattleControllerTest extends RestControllerTest {
 
                 final ResultActions actions =
                         mockMvc.perform(
-                                post("/battle").with(csrf())
+                                post("/battle")
+                                        .with(csrf())
                                         .contentType(MediaType.APPLICATION_JSON)
                                         .characterEncoding(StandardCharsets.UTF_8)
                                         .content(toRequestBody(request)));
@@ -67,19 +68,23 @@ class BattleControllerTest extends RestControllerTest {
                 return Stream.of(
                         Arguments.of(null, "body is null"),
                         Arguments.of(
-                                new BattleCreateRequest(List.of("2", "3")), "number of runners error"),
+                                new BattleCreateRequest(List.of("2", "3")),
+                                "number of runners error"),
                         Arguments.of(new BattleCreateRequest(null), "runner is null"));
             }
 
             @ParameterizedTest
             @MethodSource("invalidBattleRequest")
             @DisplayName("BadRequest를 응답한다.")
-            void returnException(BattleCreateRequest invalidRequest, String message) throws Exception {
-                given(battleService.createBattle(invalidRequest)).willThrow(new InvalidNumberOfBattleRunnerException(2));
+            void returnException(BattleCreateRequest invalidRequest, String message)
+                    throws Exception {
+                given(battleService.createBattle(invalidRequest))
+                        .willThrow(new InvalidNumberOfBattleRunnerException(2));
 
                 final ResultActions actions =
                         mockMvc.perform(
-                                post("/battle").with(csrf())
+                                post("/battle")
+                                        .with(csrf())
                                         .contentType(MediaType.APPLICATION_JSON)
                                         .characterEncoding(StandardCharsets.UTF_8)
                                         .content(toRequestBody(invalidRequest)));
@@ -108,7 +113,9 @@ class BattleControllerTest extends RestControllerTest {
                 final ResultActions actions =
                         mockMvc.perform(
                                 get("/battle/running")
-                                        .header("Authorization", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                                        .header(
+                                                "Authorization",
+                                                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
                                         .contentType(MediaType.APPLICATION_JSON)
                                         .characterEncoding(StandardCharsets.UTF_8));
 
@@ -126,12 +133,15 @@ class BattleControllerTest extends RestControllerTest {
             @Test
             @DisplayName("not found를 반환한다.")
             void getRunningBattle() throws Exception {
-                given(battleService.getRunningBattle("defaultUser")).willThrow(new RunningBattleNotFoundException("defaultUser"));
+                given(battleService.getRunningBattle("defaultUser"))
+                        .willThrow(new RunningBattleNotFoundException("defaultUser"));
 
                 final ResultActions actions =
                         mockMvc.perform(
                                 get("/battle/running")
-                                        .header("Authorization", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                                        .header(
+                                                "Authorization",
+                                                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
                                         .contentType(MediaType.APPLICATION_JSON)
                                         .characterEncoding(StandardCharsets.UTF_8));
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.List;
 import java.util.Optional;
@@ -20,14 +19,11 @@ import java.util.Optional;
 @DisplayName("BattleRepository")
 class BattleRepositoryTest {
 
-    @Autowired
-    private RunnerRepository runnerRepository;
+    @Autowired private RunnerRepository runnerRepository;
 
-    @Autowired
-    private BattleRepository battleRepository;
+    @Autowired private BattleRepository battleRepository;
 
-    @Autowired
-    MongoTemplate mongoTemplate;
+    @Autowired MongoTemplate mongoTemplate;
 
     @AfterEach
     void tearDown() {
@@ -76,8 +72,14 @@ class BattleRepositoryTest {
             @Test
             @DisplayName("현재 진행중인 상태의 배틀이 존재하면 반환한다.")
             void returnRunningBattle() {
-                final Battle 박성우_진행중_배틀 = battleRepository.findByStatusAndRunnersId(BattleStatus.RUNNING, 박성우.getId()).orElseThrow();
-                final Battle 박현준_진행중_배틀 = battleRepository.findByStatusAndRunnersId(BattleStatus.RUNNING, 박현준.getId()).orElseThrow();
+                final Battle 박성우_진행중_배틀 =
+                        battleRepository
+                                .findByStatusAndRunnersId(BattleStatus.RUNNING, 박성우.getId())
+                                .orElseThrow();
+                final Battle 박현준_진행중_배틀 =
+                        battleRepository
+                                .findByStatusAndRunnersId(BattleStatus.RUNNING, 박현준.getId())
+                                .orElseThrow();
 
                 assertThat(박성우_진행중_배틀)
                         .usingRecursiveComparison()
@@ -88,7 +90,9 @@ class BattleRepositoryTest {
             @Test
             @DisplayName("현재 진행중인 상태의 배틀이 존재하지않으면 빈 값을 반환한다.")
             void returnEmpty() {
-                final Optional<Battle> 노준혁_진행중_배틀 = battleRepository.findByStatusAndRunnersId(BattleStatus.RUNNING, 노준혁.getId());
+                final Optional<Battle> 노준혁_진행중_배틀 =
+                        battleRepository.findByStatusAndRunnersId(
+                                BattleStatus.RUNNING, 노준혁.getId());
 
                 assertThat(노준혁_진행중_배틀).isEmpty();
             }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -10,16 +10,29 @@ import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepo
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.repository.MongoRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 @DataMongoTest
 @DisplayName("BattleRepository")
 class BattleRepositoryTest {
 
-    @Autowired private RunnerRepository runnerRepository;
+    @Autowired
+    private RunnerRepository runnerRepository;
 
-    @Autowired private BattleRepository battleRepository;
+    @Autowired
+    private BattleRepository battleRepository;
+
+    @Autowired
+    MongoTemplate mongoTemplate;
+
+    @AfterEach
+    void tearDown() {
+        mongoTemplate.getDb().drop();
+    }
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -29,26 +42,56 @@ class BattleRepositoryTest {
         Runner 박현준 = runnerRepository.save(new Runner("박현준"));
         Runner 노준혁 = runnerRepository.save(new Runner("노준혁"));
 
-        @Test
-        @DisplayName("현재 참여중인 배틀이 없으면 빈 리스트를 반환한다.")
-        void returnEmpty() {
-            final List<Battle> actual =
-                    battleRepository.findByStatusAndRunnersIn(
-                            BattleStatus.RUNNING, List.of(박성우, 박현준, 노준혁));
-            assertThat(actual).isEmpty();
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class findByStatusAndRunnersIn은 {
+            @Test
+            @DisplayName("현재 참여중인 배틀이 없으면 빈 리스트를 반환한다.")
+            void returnEmpty() {
+                final List<Battle> actual =
+                        battleRepository.findByStatusAndRunnersIn(
+                                BattleStatus.RUNNING, List.of(박성우, 박현준, 노준혁));
+                assertThat(actual).isEmpty();
+            }
+
+            @Test
+            @DisplayName("현재 참여중인 배틀이 있으면 참여한 배틀 리스트를 반환한다.")
+            void returnListBattle() {
+                final Battle battle1 = battleRepository.save(new Battle(List.of(박성우, 박현준)));
+                final Battle battle2 = battleRepository.save(new Battle(List.of(노준혁)));
+
+                final List<Battle> actual =
+                        battleRepository.findByStatusAndRunnersIn(
+                                BattleStatus.RUNNING, List.of(박성우, 박현준, 노준혁));
+
+                assertThat(actual).usingRecursiveComparison().isEqualTo(List.of(battle1, battle2));
+            }
         }
 
-        @Test
-        @DisplayName("현재 참여중인 배틀이 있으면 참여한 배틀 리스트를 반환한다.")
-        void returnListBattle() {
-            final Battle battle1 = battleRepository.save(new Battle(List.of(박성우, 박현준)));
-            final Battle battle2 = battleRepository.save(new Battle(List.of(노준혁)));
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class findByStatusAndRunnersId는 {
+            Battle battle = battleRepository.save(new Battle(List.of(박성우, 박현준)));
 
-            final List<Battle> actual =
-                    battleRepository.findByStatusAndRunnersIn(
-                            BattleStatus.RUNNING, List.of(박성우, 박현준, 노준혁));
+            @Test
+            @DisplayName("현재 진행중인 상태의 배틀이 존재하면 반환한다.")
+            void returnRunningBattle() {
+                final Battle 박성우_진행중_배틀 = battleRepository.findByStatusAndRunnersId(BattleStatus.RUNNING, 박성우.getId()).orElseThrow();
+                final Battle 박현준_진행중_배틀 = battleRepository.findByStatusAndRunnersId(BattleStatus.RUNNING, 박현준.getId()).orElseThrow();
 
-            assertThat(actual).usingRecursiveComparison().isEqualTo(List.of(battle1, battle2));
+                assertThat(박성우_진행중_배틀)
+                        .usingRecursiveComparison()
+                        .isEqualTo(박현준_진행중_배틀)
+                        .isEqualTo(battle);
+            }
+
+            @Test
+            @DisplayName("현재 진행중인 상태의 배틀이 존재하지않으면 빈 값을 반환한다.")
+            void returnEmpty() {
+                final Optional<Battle> 노준혁_진행중_배틀 = battleRepository.findByStatusAndRunnersId(BattleStatus.RUNNING, 노준혁.getId());
+
+                assertThat(노준혁_진행중_배틀).isEmpty();
+            }
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,11 +1,15 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.RunnerAlreadyRunningInBattleException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.RunningBattleNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,21 +17,15 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 @SpringBootTest
 @DisplayName("BattleService")
 class BattleServiceTest {
 
-    @Autowired
-    BattleService battleService;
+    @Autowired BattleService battleService;
 
-    @Autowired
-    RunnerRepository runnerRepository;
+    @Autowired RunnerRepository runnerRepository;
 
-    @Autowired
-    MongoTemplate mongoTemplate;
+    @Autowired MongoTemplate mongoTemplate;
 
     @AfterEach
     void setUp() {
@@ -41,7 +39,8 @@ class BattleServiceTest {
         Runner 박성우 = runnerRepository.save(new Runner("박성우"));
         Runner 박현준 = runnerRepository.save(new Runner("박현준"));
         Runner 노준혁 = runnerRepository.save(new Runner("노준혁"));
-        BattleCreateRequest request = new BattleCreateRequest(List.of(박성우.getId(), 박현준.getId(), 노준혁.getId()));
+        BattleCreateRequest request =
+                new BattleCreateRequest(List.of(박성우.getId(), 박현준.getId(), 노준혁.getId()));
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -53,7 +52,6 @@ class BattleServiceTest {
                 assertThat(response.id()).isNotNull();
             }
         }
-
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -82,12 +80,13 @@ class BattleServiceTest {
                 battleService.createBattle(request);
 
                 assertThatThrownBy(
-                        () -> battleService.createBattle(
-                                new BattleCreateRequest(
-                                        List.of(
-                                                박성우.getId(),
-                                                장세연.getId(),
-                                                이승열.getId()))))
+                                () ->
+                                        battleService.createBattle(
+                                                new BattleCreateRequest(
+                                                        List.of(
+                                                                박성우.getId(),
+                                                                장세연.getId(),
+                                                                이승열.getId()))))
                         .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
             }
         }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,20 +1,20 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.RunnerAlreadyRunningInBattleException;
+import online.partyrun.partyrunbattleservice.domain.battle.exception.RunningBattleNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
 
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @DisplayName("BattleService")
@@ -37,12 +37,11 @@ class BattleServiceTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 배틀을_생성할_때 {
+
         Runner 박성우 = runnerRepository.save(new Runner("박성우"));
         Runner 박현준 = runnerRepository.save(new Runner("박현준"));
         Runner 노준혁 = runnerRepository.save(new Runner("노준혁"));
-
-        BattleCreateRequest request =
-                new BattleCreateRequest(List.of(박성우.getId(), 박현준.getId(), 노준혁.getId()));
+        BattleCreateRequest request = new BattleCreateRequest(List.of(박성우.getId(), 박현준.getId(), 노준혁.getId()));
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -59,11 +58,11 @@ class BattleServiceTest {
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class 러너들이_현재_다른_배틀에_모두_참여하고_있다면 {
-            BattleResponse battleResponse = battleService.createBattle(request);
 
             @Test
             @DisplayName("예외를 던진다.")
             void throwExceptionsByAllRunner() {
+                battleService.createBattle(request);
 
                 assertThatThrownBy(() -> battleService.createBattle(request))
                         .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
@@ -73,23 +72,58 @@ class BattleServiceTest {
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class 한명이라도_다른_배틀에_참여하고_있는_러너가_있다면 {
+            Runner 장세연 = runnerRepository.save(new Runner("장세연"));
+            Runner 이승열 = runnerRepository.save(new Runner("이승열"));
+
             @Test
             @DisplayName("예외를 던진다.")
             void throwExceptionsByOneRunner() {
-                Runner 장세연 = runnerRepository.save(new Runner("장세연"));
-                Runner 이승열 = runnerRepository.save(new Runner("이승열"));
 
                 battleService.createBattle(request);
 
                 assertThatThrownBy(
-                        () ->
-                                battleService.createBattle(
-                                        new BattleCreateRequest(
-                                                List.of(
-                                                        박성우.getId(),
-                                                        장세연.getId(),
-                                                        이승열.getId()))))
+                        () -> battleService.createBattle(
+                                new BattleCreateRequest(
+                                        List.of(
+                                                박성우.getId(),
+                                                장세연.getId(),
+                                                이승열.getId()))))
                         .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 배틀을_조회할_때 {
+
+        Runner 박성우 = runnerRepository.save(new Runner("박성우"));
+        BattleCreateRequest request = new BattleCreateRequest(List.of(박성우.getId()));
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class runner의_id가_주어지면 {
+
+            @Test
+            @DisplayName("진행중인 battle 정보 반환한다.")
+            void returnBattleId() {
+                battleService.createBattle(request);
+
+                final BattleResponse response = battleService.getRunningBattle(박성우.getId());
+                assertThat(response.id()).isNotNull();
+            }
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 현재_배틀에_참여하고있지_않는_runner의_id가_주어지면 {
+            Runner 노준혁 = runnerRepository.save(new Runner("노준혁"));
+
+            @Test
+            @DisplayName("예외를 던진다.")
+            void throwException() {
+                assertThatThrownBy(() -> battleService.getRunningBattle(노준혁.getId()))
+                        .isInstanceOf(RunningBattleNotFoundException.class);
             }
         }
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -20,11 +20,14 @@ import java.util.List;
 @DisplayName("BattleService")
 class BattleServiceTest {
 
-    @Autowired BattleService battleService;
+    @Autowired
+    BattleService battleService;
 
-    @Autowired RunnerRepository runnerRepository;
+    @Autowired
+    RunnerRepository runnerRepository;
 
-    @Autowired MongoTemplate mongoTemplate;
+    @Autowired
+    MongoTemplate mongoTemplate;
 
     @AfterEach
     void setUp() {
@@ -33,7 +36,7 @@ class BattleServiceTest {
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-    class 배틀에_참가하는_러너들의_id가_주어지면 {
+    class 배틀을_생성할_때 {
         Runner 박성우 = runnerRepository.save(new Runner("박성우"));
         Runner 박현준 = runnerRepository.save(new Runner("박현준"));
         Runner 노준혁 = runnerRepository.save(new Runner("노준혁"));
@@ -41,39 +44,53 @@ class BattleServiceTest {
         BattleCreateRequest request =
                 new BattleCreateRequest(List.of(박성우.getId(), 박현준.getId(), 노준혁.getId()));
 
-        @Test
-        @DisplayName("현재 배틀에 참여하는 러너가 없다면, 생성된 배틀의 정보를 반환한다.")
-        void returnBattle() {
-            final BattleResponse response = battleService.createBattle(request);
-            assertThat(response.id()).isNotNull();
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 현재_배틀에_참여하고_있는_러너가_없다면 {
+            @Test
+            @DisplayName(" 생성된 배틀의 정보를 반환한다.")
+            void returnBattle() {
+                final BattleResponse response = battleService.createBattle(request);
+                assertThat(response.id()).isNotNull();
+            }
         }
 
-        @Test
-        @DisplayName("러너들이 현재 다른 배틀에 모두 참여하고 있다면, 예외를 던진다.")
-        void throwExceptionsByAllRunner() {
-            battleService.createBattle(request);
 
-            assertThatThrownBy(() -> battleService.createBattle(request))
-                    .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 러너들이_현재_다른_배틀에_모두_참여하고_있다면 {
+            BattleResponse battleResponse = battleService.createBattle(request);
+
+            @Test
+            @DisplayName("예외를 던진다.")
+            void throwExceptionsByAllRunner() {
+
+                assertThatThrownBy(() -> battleService.createBattle(request))
+                        .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
+            }
         }
 
-        @Test
-        @DisplayName("한명이라도 다른 배틀에 참여하고 있는 러너가 있다면, 예외를 던진다.")
-        void throwExceptionsByOneRunner() {
-            Runner 장세연 = runnerRepository.save(new Runner("장세연"));
-            Runner 이승열 = runnerRepository.save(new Runner("이승열"));
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 한명이라도_다른_배틀에_참여하고_있는_러너가_있다면 {
+            @Test
+            @DisplayName("예외를 던진다.")
+            void throwExceptionsByOneRunner() {
+                Runner 장세연 = runnerRepository.save(new Runner("장세연"));
+                Runner 이승열 = runnerRepository.save(new Runner("이승열"));
 
-            battleService.createBattle(request);
+                battleService.createBattle(request);
 
-            assertThatThrownBy(
-                            () ->
-                                    battleService.createBattle(
-                                            new BattleCreateRequest(
-                                                    List.of(
-                                                            박성우.getId(),
-                                                            장세연.getId(),
-                                                            이승열.getId()))))
-                    .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
+                assertThatThrownBy(
+                        () ->
+                                battleService.createBattle(
+                                        new BattleCreateRequest(
+                                                List.of(
+                                                        박성우.getId(),
+                                                        장세연.getId(),
+                                                        이승열.getId()))))
+                        .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
+            }
         }
     }
 }


### PR DESCRIPTION
## 변경 사항
클라이언트가 현재 진행중(running) 상태인 battle 정보를 조회하는 API를 구현하였습니다.

## 알아야할 사항
1. security-manager 를 도입하였습니다.
이로인해 서비스간 통신을 해야하는 배틀 생성 요청은 필터에서 제외되도록 변경하였습니다.
```yaml
auth:
  filter:
    exclusions: "battle"
```

배틀 조회 요청에는 security가 적용됩니다. 따라서 `BattleAuthorizationRegistry`를 추가하였습니다.


2. 인수 테스트 추가
함께 이야기를 나눈 결과 `@WebMvcTest`에서는 우리가 만든 시큐리티 적용이 어렵기 때문에, 시큐리티 적용에 대한 테스트는 인수테스트에서 진행해야겠다고 결론이 나왔습니다.

인수 테스트는 RestAssured를 통해 구현하였습니다.
RestAssured는 더 쉽게 사용할 수 있게 SimpleRestAssured를 만들어, test-manager에 분리할 예정입니다. 
동작 과정을 모르겠으면 바로 물어봐주세요!
