### PR TITLE
클라이언트와 서버간의 웹소켓 연결을 진행한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/global/config/WebSocketConfig.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/config/WebSocketConfig.java
@@ -1,0 +1,23 @@
+package online.partyrun.partyrunbattleservice.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.enableSimpleBroker("/topic");
+        registry.setApplicationDestinationPrefixes("/pub");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/battle/ws").setAllowedOrigins("*");
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/acceptance/AcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/acceptance/AcceptanceTest.java
@@ -12,7 +12,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public abstract class AcceptanceTest {
 
-    @LocalServerPort private int port;
+    @LocalServerPort protected int port;
 
     @BeforeEach
     public void setUp() {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -1,0 +1,74 @@
+package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
+
+import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
+import online.partyrun.partyrunbattleservice.domain.battle.config.WebSocketTestConfiguration;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.messaging.simp.stomp.StompSession;
+import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
+import org.springframework.web.socket.WebSocketHttpHeaders;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Import(WebSocketTestConfiguration.class)
+@DisplayName("BattleWebSocketAcceptance")
+public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
+
+    @Autowired
+    WebSocketStompClient webSocketStompClient;
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 웹_소켓_연결을_실행할_때 {
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 정상적인_러너가_요청한다면 {
+            String accessToken = "eyJhbGciOiJIUzUxMiJ9.eyJpZCI6IuuwleyEseyasCIsInJvbGUiOlsiUk9MRV9VU0VSIl0sImV4cCI6MTAxNjg4MTk0Mzk2fQ.zRmofIpdozhKUCNijYkrOnUIlC5y4oY136FAJqJLKL_CMAdZR1c_QDbxaGym5nmrAJJ2c7dyf7qgAig70n5org";
+
+            @Test
+            @DisplayName("연결에 성공한다.")
+            void successToConnection() throws Exception {
+
+                WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
+                headers.add("Authorization", accessToken);
+
+                final CompletableFuture<StompSession> stompSessionFuture = webSocketStompClient.connectAsync(
+                        "ws://localhost:" + port + "/api/battle/ws",
+                        headers,
+                        new StompSessionHandlerAdapter() {
+                        });
+
+                assertThat(stompSessionFuture.get()).isNotNull();
+            }
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 비정상적인_러너가_요청한다면 {
+            String invalidAccessToken = "invalid.access.token";
+
+            @Test
+            @DisplayName("연결에 실패한다.")
+            void failToConnection() {
+
+                WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
+                headers.add("Authorization", invalidAccessToken);
+
+                final CompletableFuture<StompSession> stompSessionFuture = webSocketStompClient.connectAsync(
+                        "ws://localhost:" + port + "/api/battle/ws",
+                        headers,
+                        new StompSessionHandlerAdapter() {
+                        });
+
+                assertThatThrownBy(stompSessionFuture::get)
+                        .isInstanceOf(Exception.class);
+            }
+        }
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -1,7 +1,11 @@
 package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.config.WebSocketTestConfiguration;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -12,15 +16,11 @@ import org.springframework.web.socket.messaging.WebSocketStompClient;
 
 import java.util.concurrent.CompletableFuture;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 @Import(WebSocketTestConfiguration.class)
 @DisplayName("BattleWebSocketAcceptance")
 public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
 
-    @Autowired
-    WebSocketStompClient webSocketStompClient;
+    @Autowired WebSocketStompClient webSocketStompClient;
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -29,7 +29,8 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class 정상적인_러너가_요청한다면 {
-            String accessToken = "eyJhbGciOiJIUzUxMiJ9.eyJpZCI6IuuwleyEseyasCIsInJvbGUiOlsiUk9MRV9VU0VSIl0sImV4cCI6MTAxNjg4MTk0Mzk2fQ.zRmofIpdozhKUCNijYkrOnUIlC5y4oY136FAJqJLKL_CMAdZR1c_QDbxaGym5nmrAJJ2c7dyf7qgAig70n5org";
+            String accessToken =
+                    "eyJhbGciOiJIUzUxMiJ9.eyJpZCI6IuuwleyEseyasCIsInJvbGUiOlsiUk9MRV9VU0VSIl0sImV4cCI6MTAxNjg4MTk0Mzk2fQ.zRmofIpdozhKUCNijYkrOnUIlC5y4oY136FAJqJLKL_CMAdZR1c_QDbxaGym5nmrAJJ2c7dyf7qgAig70n5org";
 
             @Test
             @DisplayName("연결에 성공한다.")
@@ -38,11 +39,11 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                 WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
                 headers.add("Authorization", accessToken);
 
-                final CompletableFuture<StompSession> stompSessionFuture = webSocketStompClient.connectAsync(
-                        "ws://localhost:" + port + "/api/battle/ws",
-                        headers,
-                        new StompSessionHandlerAdapter() {
-                        });
+                final CompletableFuture<StompSession> stompSessionFuture =
+                        webSocketStompClient.connectAsync(
+                                "ws://localhost:" + port + "/api/battle/ws",
+                                headers,
+                                new StompSessionHandlerAdapter() {});
 
                 assertThat(stompSessionFuture.get()).isNotNull();
             }
@@ -60,14 +61,13 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                 WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
                 headers.add("Authorization", invalidAccessToken);
 
-                final CompletableFuture<StompSession> stompSessionFuture = webSocketStompClient.connectAsync(
-                        "ws://localhost:" + port + "/api/battle/ws",
-                        headers,
-                        new StompSessionHandlerAdapter() {
-                        });
+                final CompletableFuture<StompSession> stompSessionFuture =
+                        webSocketStompClient.connectAsync(
+                                "ws://localhost:" + port + "/api/battle/ws",
+                                headers,
+                                new StompSessionHandlerAdapter() {});
 
-                assertThatThrownBy(stompSessionFuture::get)
-                        .isInstanceOf(Exception.class);
+                assertThatThrownBy(stompSessionFuture::get).isInstanceOf(Exception.class);
             }
         }
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/config/WebSocketTestConfiguration.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/config/WebSocketTestConfiguration.java
@@ -1,0 +1,31 @@
+package online.partyrun.partyrunbattleservice.domain.battle.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.messaging.converter.MappingJackson2MessageConverter;
+import org.springframework.scheduling.TaskScheduler;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.web.socket.client.WebSocketClient;
+import org.springframework.web.socket.client.standard.StandardWebSocketClient;
+import org.springframework.web.socket.messaging.WebSocketStompClient;
+
+@TestConfiguration
+public class WebSocketTestConfiguration {
+
+    @Bean
+    public WebSocketStompClient webSocketStompClient() {
+        WebSocketClient webSocketClient = new StandardWebSocketClient();
+        WebSocketStompClient stompClient = new WebSocketStompClient(webSocketClient);
+        stompClient.setMessageConverter(new MappingJackson2MessageConverter());
+        stompClient.setTaskScheduler(taskScheduler());
+        return stompClient;
+    }
+
+    public TaskScheduler taskScheduler() {
+        ThreadPoolTaskScheduler taskScheduler = new ThreadPoolTaskScheduler();
+        taskScheduler.setPoolSize(1);
+        taskScheduler.setThreadNamePrefix("StompHeartbeatThread-");
+        taskScheduler.initialize();
+        return taskScheduler;
+    }
+}


### PR DESCRIPTION
## 변경 사항
배틀을 진행하기위해서 웹소켓 연결을 해야합니다. 이를 위해 WebSocketConfig 파일을 추가하였습니다.

## 알아야할 사항
BattleWebSocketAcceptanceTest를 통해서 어떻게 연결을 진행하는지 확인할 수 있습니다.
클라이언트가 `/battle/ws` 로 웹소켓 요청을 보내면, 웹소켓 연결을 진행합니다.

이 때 스프링 시큐리티가 동작해서 정상적이지 않은 러너가 요청을 한다면, 403 응답을 받게 됩니다.

테스트의 내용은 웹소켓 연결이 성공되었다면, StompSession이 Not Null이 되고, 실패하였다면 예외가 발생합니다.


