### PR TITLE
사용자에 따라 구독을 막을지 설정한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,7 @@ jacocoTestCoverageVerification {
                     '**.*Exception*',
                     '**.*Mapper*',
                     '**.*ControllerAdvice*',
+                    '**.*Interceptor*'
             ]
         }
 

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -6,8 +6,11 @@
 :sectlinks:
 
 = Battle
-== 배틀 생성
+
+=== 배틀 생성
+
 operation::create battle[snippets='http-request,http-response']
+---
 
 === 배틀 생성 실패
 body가 null일 때

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/BattleChannelInterceptor.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/BattleChannelInterceptor.java
@@ -3,9 +3,11 @@ package online.partyrun.partyrunbattleservice.domain.battle.config;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidSubscribeRequestException;
 import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
+
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/BattleChannelInterceptor.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/BattleChannelInterceptor.java
@@ -1,0 +1,64 @@
+package online.partyrun.partyrunbattleservice.domain.battle.config;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
+import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
+import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidSubscribeRequestException;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.stereotype.Component;
+
+import java.security.Principal;
+import java.util.Objects;
+
+@Component
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class BattleChannelInterceptor implements ChannelInterceptor {
+
+    static String BATTLE_TOPIC_PREFIX = "/topic/battle";
+    BattleRepository battleRepository;
+
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
+
+        if (isSubscribeToBattleTopic(accessor)) {
+            validateSubscription(accessor);
+        }
+
+        return message;
+    }
+
+    private boolean isSubscribeToBattleTopic(StompHeaderAccessor accessor) {
+        final String destination = accessor.getDestination();
+        return StompCommand.SUBSCRIBE.equals(accessor.getCommand()) &&
+                Objects.nonNull(destination) &&
+                destination.startsWith(BATTLE_TOPIC_PREFIX);
+    }
+
+    private void validateSubscription(StompHeaderAccessor accessor) {
+        final String runnerId = getRunnerId(accessor);
+        String battleId = extractBattleId(accessor);
+
+        if (!battleRepository.existsByIdAndRunnersIdAndStatus(battleId, runnerId, BattleStatus.RUNNING)) {
+            throw new InvalidSubscribeRequestException(battleId, runnerId);
+        }
+    }
+
+    private String getRunnerId(StompHeaderAccessor accessor) {
+        final Principal auth = Objects.requireNonNull(accessor.getUser());
+        return Objects.requireNonNull(auth.getName());
+    }
+
+    private String extractBattleId(StompHeaderAccessor accessor) {
+        final String destination = Objects.requireNonNull(accessor.getDestination());
+        final String[] parts = destination.split(BATTLE_TOPIC_PREFIX);
+        return parts[parts.length - 1];
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/BattleChannelInterceptor.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/BattleChannelInterceptor.java
@@ -4,8 +4,8 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
-import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidSubscribeRequestException;
+import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
 import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
@@ -21,7 +21,7 @@ import java.util.Objects;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class BattleChannelInterceptor implements ChannelInterceptor {
 
-    static String BATTLE_TOPIC_PREFIX = "/topic/battle";
+    static String BATTLE_TOPIC_PREFIX = "/topic/battle/";
     BattleRepository battleRepository;
 
     @Override
@@ -37,16 +37,18 @@ public class BattleChannelInterceptor implements ChannelInterceptor {
 
     private boolean isSubscribeToBattleTopic(StompHeaderAccessor accessor) {
         final String destination = accessor.getDestination();
-        return StompCommand.SUBSCRIBE.equals(accessor.getCommand()) &&
-                Objects.nonNull(destination) &&
-                destination.startsWith(BATTLE_TOPIC_PREFIX);
+        return StompCommand.SUBSCRIBE.equals(accessor.getCommand())
+                && Objects.nonNull(destination)
+                && destination.contains(BATTLE_TOPIC_PREFIX);
     }
 
     private void validateSubscription(StompHeaderAccessor accessor) {
         final String runnerId = getRunnerId(accessor);
         String battleId = extractBattleId(accessor);
 
-        if (!battleRepository.existsByIdAndRunnersIdAndStatus(battleId, runnerId, BattleStatus.RUNNING)) {
+        if (!battleRepository.existsByIdAndRunnersIdAndStatus(
+                battleId, runnerId, BattleStatus.RUNNING)) {
+
             throw new InvalidSubscribeRequestException(battleId, runnerId);
         }
     }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/WebSocketConfig.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/WebSocketConfig.java
@@ -21,7 +21,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/topic", "/queue");
+        registry.enableSimpleBroker("/topic");
         registry.setApplicationDestinationPrefixes("/pub");
     }
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/WebSocketConfig.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/WebSocketConfig.java
@@ -1,6 +1,10 @@
-package online.partyrun.partyrunbattleservice.global.config;
+package online.partyrun.partyrunbattleservice.domain.battle.config;
 
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
@@ -8,7 +12,11 @@ import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerCo
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    BattleChannelInterceptor battleChannelInterceptor;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -20,4 +28,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/battle/ws").setAllowedOrigins("*");
     }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(battleChannelInterceptor);
+    }
 }
+

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/WebSocketConfig.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/WebSocketConfig.java
@@ -3,6 +3,7 @@ package online.partyrun.partyrunbattleservice.domain.battle.config;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
@@ -20,7 +21,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/topic");
+        registry.enableSimpleBroker("/topic", "/queue");
         registry.setApplicationDestinationPrefixes("/pub");
     }
 
@@ -34,4 +35,3 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registration.interceptors(battleChannelInterceptor);
     }
 }
-

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleWebsocketController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleWebsocketController.java
@@ -1,0 +1,24 @@
+package online.partyrun.partyrunbattleservice.domain.battle.controller;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import online.partyrun.partyrunbattleservice.domain.battle.dto.LocationDto;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Slf4j
+@Controller
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class BattleWebsocketController {
+    SimpMessagingTemplate messagingTemplate;
+
+    @MessageMapping("/battle/{battleId}")
+    public void messageMapping(@DestinationVariable String battleId, LocationDto request) {
+        this.messagingTemplate.convertAndSend("/topic/battle/" + battleId, request);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleWebsocketController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleWebsocketController.java
@@ -4,7 +4,9 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.LocationDto;
+
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessagingTemplate;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/dto/LocationDto.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/dto/LocationDto.java
@@ -1,0 +1,14 @@
+package online.partyrun.partyrunbattleservice.domain.battle.dto;
+
+import lombok.*;
+import lombok.experimental.FieldDefaults;
+
+@NoArgsConstructor
+@Getter
+@AllArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class LocationDto {
+    int x;
+    int y;
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
-import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
@@ -2,6 +2,7 @@ package online.partyrun.partyrunbattleservice.domain.battle.entity;
 
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
 import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
@@ -13,6 +14,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
+@NoArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Battle {
     @Id String id;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/InvalidSubscribeRequestException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/InvalidSubscribeRequestException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunbattleservice.domain.battle.exception;
+
+import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
+
+public class InvalidSubscribeRequestException extends BadRequestException {
+    public InvalidSubscribeRequestException(String battleId, String runnerId) {
+        super(String.format("%s 러너는 %s 배틀을 구독할 수 없습니다.", runnerId, battleId));
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/RunnerAlreadyRunningInBattleException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/RunnerAlreadyRunningInBattleException.java
@@ -1,7 +1,7 @@
 package online.partyrun.partyrunbattleservice.domain.battle.exception;
 
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
-import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
 
 import java.util.List;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -2,7 +2,7 @@ package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
-import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -13,4 +13,6 @@ public interface BattleRepository extends MongoRepository<Battle, String> {
     List<Battle> findByStatusAndRunnersIn(BattleStatus status, List<Runner> runners);
 
     Optional<Battle> findByStatusAndRunnersId(BattleStatus status, String runnersId);
+
+    boolean existsByIdAndRunnersIdAndStatus(String battleId, String runnerId, BattleStatus status);
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -12,7 +12,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.RunnerAlreadyRunningInBattleException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.RunningBattleNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
-import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.service.RunnerService;
 
 import org.springframework.stereotype.Service;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
@@ -1,4 +1,4 @@
-package online.partyrun.partyrunbattleservice.domain.runner.entuty;
+package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerStatus.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerStatus.java
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunbattleservice.domain.runner.entity;
+
+public enum RunnerStatus {
+    READY, RUNNING, FINISHED
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerStatus.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerStatus.java
@@ -1,5 +1,7 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
 public enum RunnerStatus {
-    READY, RUNNING, FINISHED
+    READY,
+    RUNNING,
+    FINISHED
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entuty/Runner.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entuty/Runner.java
@@ -2,14 +2,17 @@ package online.partyrun.partyrunbattleservice.domain.runner.entuty;
 
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
 import org.springframework.data.annotation.Id;
 
 @Getter
-@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@NoArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE)
 public class Runner {
     @Id String id;
+    RunnerStatus status = RunnerStatus.READY;
 
     public Runner(String id) {
         this.id = id;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entuty/RunnerStatus.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entuty/RunnerStatus.java
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunbattleservice.domain.runner.entuty;
+
+public enum RunnerStatus {
+    READY, RUNNING, FINISHED
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entuty/RunnerStatus.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entuty/RunnerStatus.java
@@ -1,5 +1,0 @@
-package online.partyrun.partyrunbattleservice.domain.runner.entuty;
-
-public enum RunnerStatus {
-    READY, RUNNING, FINISHED
-}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/repository/RunnerRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/repository/RunnerRepository.java
@@ -1,6 +1,6 @@
 package online.partyrun.partyrunbattleservice.domain.runner.repository;
 
-import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/service/RunnerService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/service/RunnerService.java
@@ -4,7 +4,7 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
-import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidRunnerException;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
 
@@ -18,6 +18,8 @@ import java.util.List;
 public class RunnerService {
 
     RunnerRepository runnerRepository;
+
+    // TODO: 2023/07/04 MemberRepository에서 가져와서 runner 생성하는 로직으로 변경하기
 
     public List<Runner> findAllById(List<String> runnerIds) {
         final List<Runner> runners = runnerRepository.findAllById(runnerIds);

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleAcceptanceTest.java
@@ -14,7 +14,7 @@ import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
-import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
 
 import org.junit.jupiter.api.*;

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleRestAssuredRequest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleRestAssuredRequest.java
@@ -8,11 +8,11 @@ import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateReque
 
 import java.util.Map;
 
-public class BattleRestAssuredRequest {
+public abstract class BattleRestAssuredRequest {
     private static final String PREFIX_URL = "api";
     private static final String BATTLE_URL = "battle";
 
-    public static final ExtractableResponse<Response> 배틀_생성_요청(
+    public static ExtractableResponse<Response> 배틀_생성_요청(
             String systemToken, BattleCreateRequest request) {
         return SimpleRestAssured.post(
                 String.format("/%s/%s", PREFIX_URL, BATTLE_URL),
@@ -20,7 +20,7 @@ public class BattleRestAssuredRequest {
                 request);
     }
 
-    public static final ExtractableResponse<Response> 배틀_조회_요청(String accessToken) {
+    public static ExtractableResponse<Response> 배틀_조회_요청(String accessToken) {
         return SimpleRestAssured.get(
                 String.format("/%s/%s/running", PREFIX_URL, BATTLE_URL),
                 Map.of("Authorization", accessToken));

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -6,7 +6,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.config.WebSocketTestC
 import online.partyrun.partyrunbattleservice.domain.battle.dto.LocationDto;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
-import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -1,5 +1,8 @@
 package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.config.WebSocketTestConfiguration;
@@ -8,6 +11,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -20,21 +24,14 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 @Import(WebSocketTestConfiguration.class)
 @DisplayName("BattleWebSocketAcceptance")
 public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
 
-    @Autowired
-    WebSocketStompClient webSocketStompClient;
-    @Autowired
-    BattleRepository battleRepository;
-    @Autowired
-    RunnerRepository runnerRepository;
-    @Autowired
-    JwtGenerator jwtGenerator;
+    @Autowired WebSocketStompClient webSocketStompClient;
+    @Autowired BattleRepository battleRepository;
+    @Autowired RunnerRepository runnerRepository;
+    @Autowired JwtGenerator jwtGenerator;
     BlockingQueue<LocationDto> locationQueue = new LinkedBlockingDeque<>();
 
     private CompletableFuture<StompSession> 웹소켓_연결(String accessToken) {
@@ -45,8 +42,7 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                 webSocketStompClient.connectAsync(
                         "ws://localhost:" + port + "/api/battle/ws",
                         headers,
-                        new StompSessionHandlerAdapter() {
-                        });
+                        new StompSessionHandlerAdapter() {});
         return stompSessionFuture;
     }
 
@@ -106,14 +102,13 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                 StompSession stompSession = stompSessionFuture.get(5, TimeUnit.SECONDS);
                 stompSession.subscribe(
                         String.format("/topic/battle/%s", 배틀.getId()),
-                        new StompFrameHandlerImpl<>(new LocationDto(), locationQueue)
-                );
+                        new StompFrameHandlerImpl<>(new LocationDto(), locationQueue));
 
-                stompSession.send(String.format("/pub/battle/%s", 배틀.getId()), new LocationDto(1, 2));
+                stompSession.send(
+                        String.format("/pub/battle/%s", 배틀.getId()), new LocationDto(1, 2));
                 LocationDto result = locationQueue.poll(5, TimeUnit.SECONDS);
                 assertThat(result).isEqualTo(new LocationDto(1, 2));
             }
         }
     }
 }
-

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -1,74 +1,97 @@
 package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
+import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.config.WebSocketTestConfiguration;
-
+import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
+import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.web.socket.WebSocketHttpHeaders;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Import(WebSocketTestConfiguration.class)
 @DisplayName("BattleWebSocketAcceptance")
 public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
 
-    @Autowired WebSocketStompClient webSocketStompClient;
+    @Autowired
+    WebSocketStompClient webSocketStompClient;
+    @Autowired
+    BattleRepository battleRepository;
+    @Autowired
+    RunnerRepository runnerRepository;
+    @Autowired
+    JwtGenerator jwtGenerator;
+
+    private CompletableFuture<StompSession> 웹소켓_연결(String accessToken) {
+        WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
+        headers.add("Authorization", accessToken);
+
+        final CompletableFuture<StompSession> stompSessionFuture =
+                webSocketStompClient.connectAsync(
+                        "ws://localhost:" + port + "/api/battle/ws",
+                        headers,
+                        new StompSessionHandlerAdapter() {
+                            @Override
+                            public void handleException(
+                                    StompSession session,
+                                    StompCommand command,
+                                    StompHeaders headers,
+                                    byte[] payload,
+                                    Throwable exception) {
+                                session.disconnect();
+                            }
+                        });
+        return stompSessionFuture;
+    }
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 웹_소켓_연결을_실행할_때 {
 
+        String accessToken =
+                "eyJhbGciOiJIUzUxMiJ9.eyJpZCI6IuuwleyEseyasCIsInJvbGUiOlsiUk9MRV9VU0VSIl0sImV4cCI6MTAxNjg4MTk0Mzk2fQ.zRmofIpdozhKUCNijYkrOnUIlC5y4oY136FAJqJLKL_CMAdZR1c_QDbxaGym5nmrAJJ2c7dyf7qgAig70n5org";
+
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class 정상적인_러너가_요청한다면 {
-            String accessToken =
-                    "eyJhbGciOiJIUzUxMiJ9.eyJpZCI6IuuwleyEseyasCIsInJvbGUiOlsiUk9MRV9VU0VSIl0sImV4cCI6MTAxNjg4MTk0Mzk2fQ.zRmofIpdozhKUCNijYkrOnUIlC5y4oY136FAJqJLKL_CMAdZR1c_QDbxaGym5nmrAJJ2c7dyf7qgAig70n5org";
 
             @Test
             @DisplayName("연결에 성공한다.")
             void successToConnection() throws Exception {
+                final CompletableFuture<StompSession> stompSessionFuture = 웹소켓_연결(accessToken);
 
-                WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
-                headers.add("Authorization", accessToken);
-
-                final CompletableFuture<StompSession> stompSessionFuture =
-                        webSocketStompClient.connectAsync(
-                                "ws://localhost:" + port + "/api/battle/ws",
-                                headers,
-                                new StompSessionHandlerAdapter() {});
-
-                assertThat(stompSessionFuture.get()).isNotNull();
+                assertThat(stompSessionFuture.get(5, TimeUnit.SECONDS)).isNotNull();
             }
         }
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class 비정상적인_러너가_요청한다면 {
+
             String invalidAccessToken = "invalid.access.token";
 
             @Test
             @DisplayName("연결에 실패한다.")
             void failToConnection() {
-
-                WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
-                headers.add("Authorization", invalidAccessToken);
-
                 final CompletableFuture<StompSession> stompSessionFuture =
-                        webSocketStompClient.connectAsync(
-                                "ws://localhost:" + port + "/api/battle/ws",
-                                headers,
-                                new StompSessionHandlerAdapter() {});
+                        웹소켓_연결(invalidAccessToken);
 
-                assertThatThrownBy(stompSessionFuture::get).isInstanceOf(Exception.class);
+                assertThatThrownBy(() -> stompSessionFuture.get(5, TimeUnit.SECONDS))
+                        .isInstanceOf(Exception.class);
             }
         }
     }
 }
+

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -1,5 +1,8 @@
 package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.config.WebSocketTestConfiguration;
@@ -8,6 +11,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -20,9 +24,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.*;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 @Import(WebSocketTestConfiguration.class)
 @DisplayName("BattleWebSocketAcceptance")
 public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
@@ -32,7 +33,6 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
     @Autowired RunnerRepository runnerRepository;
     @Autowired JwtGenerator jwtGenerator;
     BlockingQueue<LocationDto> locationQueue = new LinkedBlockingDeque<>();
-
 
     private CompletableFuture<StompSession> 웹소켓_연결(String accessToken) {
         WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
@@ -45,6 +45,7 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                         new StompSessionHandlerAdapter() {});
         return stompSessionFuture;
     }
+
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 웹_소켓_연결을_실행할_때 {
@@ -62,8 +63,8 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
 
                 assertThat(stompSessionFuture.get(5, TimeUnit.SECONDS)).isNotNull();
             }
-
         }
+
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class 비정상적인_러너가_요청한다면 {
@@ -80,8 +81,8 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                         .isInstanceOf(Exception.class);
             }
         }
-
     }
+
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 웹소켓_연결에_성공했을_때 {
@@ -115,6 +116,7 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
         class 구독_요청에_실패하면 {
             Runner 박현준 = runnerRepository.save(new Runner("박현준"));
             Battle 박현준_배틀 = battleRepository.save(new Battle(List.of(박현준)));
+
             @Test
             @DisplayName("메시지를 받을 수 없다")
             void getMessage() throws ExecutionException, InterruptedException, TimeoutException {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -3,20 +3,22 @@ package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.config.WebSocketTestConfiguration;
+import online.partyrun.partyrunbattleservice.domain.battle.dto.LocationDto;
+import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
+import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
-import org.springframework.messaging.simp.stomp.StompCommand;
-import org.springframework.messaging.simp.stomp.StompHeaders;
 import org.springframework.messaging.simp.stomp.StompSession;
 import org.springframework.messaging.simp.stomp.StompSessionHandlerAdapter;
 import org.springframework.web.socket.WebSocketHttpHeaders;
 import org.springframework.web.socket.messaging.WebSocketStompClient;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -33,6 +35,7 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
     RunnerRepository runnerRepository;
     @Autowired
     JwtGenerator jwtGenerator;
+    BlockingQueue<LocationDto> locationQueue = new LinkedBlockingDeque<>();
 
     private CompletableFuture<StompSession> 웹소켓_연결(String accessToken) {
         WebSocketHttpHeaders headers = new WebSocketHttpHeaders();
@@ -43,15 +46,6 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                         "ws://localhost:" + port + "/api/battle/ws",
                         headers,
                         new StompSessionHandlerAdapter() {
-                            @Override
-                            public void handleException(
-                                    StompSession session,
-                                    StompCommand command,
-                                    StompHeaders headers,
-                                    byte[] payload,
-                                    Throwable exception) {
-                                session.disconnect();
-                            }
                         });
         return stompSessionFuture;
     }
@@ -59,9 +53,8 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 웹_소켓_연결을_실행할_때 {
-
-        String accessToken =
-                "eyJhbGciOiJIUzUxMiJ9.eyJpZCI6IuuwleyEseyasCIsInJvbGUiOlsiUk9MRV9VU0VSIl0sImV4cCI6MTAxNjg4MTk0Mzk2fQ.zRmofIpdozhKUCNijYkrOnUIlC5y4oY136FAJqJLKL_CMAdZR1c_QDbxaGym5nmrAJJ2c7dyf7qgAig70n5org";
+        Runner 박성우 = runnerRepository.save(new Runner("박성우"));
+        String accessToken = jwtGenerator.generate(박성우.getId(), Set.of("ROLE_USER")).accessToken();
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -90,6 +83,35 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
 
                 assertThatThrownBy(() -> stompSessionFuture.get(5, TimeUnit.SECONDS))
                         .isInstanceOf(Exception.class);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 웹소켓_연결에_성공했을_때 {
+        Runner 박성우 = runnerRepository.save(new Runner("박성우"));
+        String accessToken = jwtGenerator.generate(박성우.getId(), Set.of("ROLE_USER")).accessToken();
+        Battle 배틀 = battleRepository.save(new Battle(List.of(박성우)));
+        CompletableFuture<StompSession> stompSessionFuture = 웹소켓_연결(accessToken);
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 구독_요청에_성공하면 {
+
+            @Test
+            @DisplayName("메시지를 받을 수 있다")
+            void getMessage() throws ExecutionException, InterruptedException, TimeoutException {
+                System.out.println(accessToken);
+                StompSession stompSession = stompSessionFuture.get(5, TimeUnit.SECONDS);
+                stompSession.subscribe(
+                        String.format("/topic/battle/%s", 배틀.getId()),
+                        new StompFrameHandlerImpl<>(new LocationDto(), locationQueue)
+                );
+
+                stompSession.send(String.format("/pub/battle/%s", 배틀.getId()), new LocationDto(1, 2));
+                LocationDto result = locationQueue.poll(5, TimeUnit.SECONDS);
+                assertThat(result).isEqualTo(new LocationDto(1, 2));
             }
         }
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/StompFrameHandlerImpl.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/StompFrameHandlerImpl.java
@@ -1,0 +1,29 @@
+package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
+
+import org.springframework.messaging.simp.stomp.StompFrameHandler;
+import org.springframework.messaging.simp.stomp.StompHeaders;
+
+import java.lang.reflect.Type;
+import java.util.concurrent.BlockingQueue;
+
+public class StompFrameHandlerImpl<T> implements StompFrameHandler {
+
+    private final T response;
+    private final BlockingQueue<T> responses;
+
+    public StompFrameHandlerImpl(final T response, final BlockingQueue<T> responses) {
+        this.response = response;
+        this.responses = responses;
+    }
+
+    @Override
+    public Type getPayloadType(final StompHeaders headers) {
+        return response.getClass();
+    }
+
+    @Override
+    public void handleFrame(final StompHeaders headers, final Object payload) {
+        System.out.println(payload);
+        responses.offer((T) payload);
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,23 +1,16 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidNumberOfBattleRunnerException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.RunningBattleNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
 import online.partyrun.testmanager.docs.RestControllerTest;
-
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
@@ -26,7 +19,15 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
 
-@DisplayName("BattleRestController")
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(BattleController.class)
+@DisplayName("BattleController")
 class BattleControllerTest extends RestControllerTest {
 
     @MockBean BattleService battleService;

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,11 +1,19 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidNumberOfBattleRunnerException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.RunningBattleNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
 import online.partyrun.testmanager.docs.RestControllerTest;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -18,13 +26,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BattleController.class)
 @DisplayName("BattleController")

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,12 +1,9 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -15,15 +12,19 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 @DataMongoTest
 @DisplayName("BattleRepository")
 class BattleRepositoryTest {
 
-    @Autowired private RunnerRepository runnerRepository;
-
-    @Autowired private BattleRepository battleRepository;
-
-    @Autowired MongoTemplate mongoTemplate;
+    @Autowired
+    MongoTemplate mongoTemplate;
+    @Autowired
+    private RunnerRepository runnerRepository;
+    @Autowired
+    private BattleRepository battleRepository;
 
     @AfterEach
     void tearDown() {
@@ -95,6 +96,31 @@ class BattleRepositoryTest {
                                 BattleStatus.RUNNING, 노준혁.getId());
 
                 assertThat(노준혁_진행중_배틀).isEmpty();
+            }
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class existsByIdAndRunnersIdAndStatus는 {
+            Battle battle1 = battleRepository.save(new Battle(List.of(박성우, 박현준)));
+
+            @Test
+            @DisplayName("battleId, runnerId, status를 만족하는 데이터의 존재하면 true를 반환한다.")
+            void returnTrue() {
+                final boolean result = battleRepository.existsByIdAndRunnersIdAndStatus(battle1.getId(), 박성우.getId(), BattleStatus.RUNNING);
+                assertThat(result).isTrue();
+            }
+
+            @Test
+            @DisplayName("battleId, runnerId, status를 만족하는 데이터가 없으면 false를 반환한다.")
+            void returnFalse() {
+                final boolean result1 = battleRepository.existsByIdAndRunnersIdAndStatus(battle1.getId(), 박성우.getId(), BattleStatus.FINISHED);
+                final boolean result2 = battleRepository.existsByIdAndRunnersIdAndStatus(battle1.getId(), 노준혁.getId(), BattleStatus.RUNNING);
+
+                assertAll(
+                        () -> assertThat(result1).isFalse(),
+                        () -> assertThat(result2).isFalse()
+                );
             }
         }
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -5,7 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
-import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
 
 import org.junit.jupiter.api.*;

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,9 +1,13 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -12,19 +16,13 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.util.List;
 import java.util.Optional;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 @DataMongoTest
 @DisplayName("BattleRepository")
 class BattleRepositoryTest {
 
-    @Autowired
-    MongoTemplate mongoTemplate;
-    @Autowired
-    private RunnerRepository runnerRepository;
-    @Autowired
-    private BattleRepository battleRepository;
+    @Autowired MongoTemplate mongoTemplate;
+    @Autowired private RunnerRepository runnerRepository;
+    @Autowired private BattleRepository battleRepository;
 
     @AfterEach
     void tearDown() {
@@ -107,20 +105,23 @@ class BattleRepositoryTest {
             @Test
             @DisplayName("battleId, runnerId, status를 만족하는 데이터의 존재하면 true를 반환한다.")
             void returnTrue() {
-                final boolean result = battleRepository.existsByIdAndRunnersIdAndStatus(battle1.getId(), 박성우.getId(), BattleStatus.RUNNING);
+                final boolean result =
+                        battleRepository.existsByIdAndRunnersIdAndStatus(
+                                battle1.getId(), 박성우.getId(), BattleStatus.RUNNING);
                 assertThat(result).isTrue();
             }
 
             @Test
             @DisplayName("battleId, runnerId, status를 만족하는 데이터가 없으면 false를 반환한다.")
             void returnFalse() {
-                final boolean result1 = battleRepository.existsByIdAndRunnersIdAndStatus(battle1.getId(), 박성우.getId(), BattleStatus.FINISHED);
-                final boolean result2 = battleRepository.existsByIdAndRunnersIdAndStatus(battle1.getId(), 노준혁.getId(), BattleStatus.RUNNING);
+                final boolean result1 =
+                        battleRepository.existsByIdAndRunnersIdAndStatus(
+                                battle1.getId(), 박성우.getId(), BattleStatus.FINISHED);
+                final boolean result2 =
+                        battleRepository.existsByIdAndRunnersIdAndStatus(
+                                battle1.getId(), 노준혁.getId(), BattleStatus.RUNNING);
 
-                assertAll(
-                        () -> assertThat(result1).isFalse(),
-                        () -> assertThat(result2).isFalse()
-                );
+                assertAll(() -> assertThat(result1).isFalse(), () -> assertThat(result2).isFalse());
             }
         }
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -7,7 +7,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateReque
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.RunnerAlreadyRunningInBattleException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.RunningBattleNotFoundException;
-import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
 
 import org.junit.jupiter.api.*;

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/service/RunnerServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/service/RunnerServiceTest.java
@@ -3,7 +3,7 @@ package online.partyrun.partyrunbattleservice.domain.runner.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import online.partyrun.partyrunbattleservice.domain.runner.entuty.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidRunnerException;
 import online.partyrun.partyrunbattleservice.domain.runner.repository.RunnerRepository;
 


### PR DESCRIPTION
## 변경 사항
사용자가 인증이 되었어도, 특정 배틀을 구독하는 것에 대해 인가를 해주어야합니다.

내가 속한 배틀이 아니지만 구독을 하려는 경우 구독에 실패하도록 로직을 작성했습니다.

컨트롤러와 테스트는 예시를 위해서 작성했습니다. (완성 아님)


## 알아야할 사항
BattleChannelInterceptor는 ChannelInterceptor를 상속받은 것으로, 디스패처 서블릿의 interceptor와 같은 원리입니다.
요청을 먼저 가로채서 배틀과 러너에 대해 확인 후, 검증에 실패하면 예외를 터뜨려 구독에 실패하도록 합니다.

<img width="1051" alt="image" src="https://github.com/SWM-KAWAI-MANS/party-run-battle-service/assets/79205414/bb7d1327-cdc7-4e79-bebb-cd1b525cb2be">


## 테스트 방식
웹소켓 클라이언트를 이용해서 실제 요청을 보내는 방식으로 구현했습니다.

웹소켓은 스레드 방식으로 동작하므로, BlockingQueue를 사용했습니다.
BlockingQueue를 사용하지 않으면 다른 스레드에서 받은 데이터가 날라가요 ,, , 
