### PR TITLE
Battle 시작 시간을 위한 이벤트를 발행하는 방식을 변경한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleEventHandler.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleEventHandler.java
@@ -4,9 +4,11 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleStartTimeResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.event.BattleRunningEvent;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
+
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Async;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleEventHandler.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleEventHandler.java
@@ -4,18 +4,13 @@ import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
-
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleStartTimeResponse;
-import online.partyrun.partyrunbattleservice.domain.battle.event.RunnerRunningEvent;
+import online.partyrun.partyrunbattleservice.domain.battle.event.BattleRunningEvent;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
-
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Controller;
-
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
 @Slf4j
 @Async
@@ -23,20 +18,12 @@ import java.util.concurrent.ConcurrentHashMap;
 @RequiredArgsConstructor
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class BattleEventHandler {
-    Map<RunnerRunningEvent, Integer> RUNNER_RUNNING_EVENTS = new ConcurrentHashMap<>();
     SimpMessagingTemplate messagingTemplate;
     BattleService battleService;
 
     @EventListener
-    public void setBattleRunning(RunnerRunningEvent event) {
-        final int eventCount = RUNNER_RUNNING_EVENTS.merge(event, 1, Integer::sum);
-
-        if (event.isTargetCount(eventCount)) {
-            final BattleStartTimeResponse response =
-                    battleService.setBattleRunning(event.battleId());
-            messagingTemplate.convertAndSend("/topic/battle/" + event.battleId(), response);
-
-            RUNNER_RUNNING_EVENTS.remove(event);
-        }
+    public void setBattleRunning(BattleRunningEvent event) {
+        final BattleStartTimeResponse response = battleService.setBattleRunning(event.battleId());
+        messagingTemplate.convertAndSend("/topic/battle/" + event.battleId(), response);
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
@@ -26,7 +26,7 @@ public class Battle {
     @Id String id;
     int distance;
     List<Runner> runners;
-    BattleStatus status = BattleStatus.READY;
+    BattleStatus status;
     LocalDateTime startTime;
     @CreatedDate LocalDateTime createdAt;
 
@@ -35,6 +35,7 @@ public class Battle {
         validateRunners(runners);
         this.distance = distance;
         this.runners = runners;
+        this.status = BattleStatus.READY;
     }
 
     private void validateDistance(int distance) {
@@ -97,7 +98,9 @@ public class Battle {
         }
     }
 
-    public int getNumberOfRunners() {
-        return this.runners.size();
+
+    public boolean isAllRunnersRunningStatus() {
+        return this.runners.stream()
+                .allMatch(Runner::isRunning);
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
@@ -98,9 +98,7 @@ public class Battle {
         }
     }
 
-
     public boolean isAllRunnersRunningStatus() {
-        return this.runners.stream()
-                .allMatch(Runner::isRunning);
+        return this.runners.stream().allMatch(Runner::isRunning);
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/BattleRunningEvent.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/BattleRunningEvent.java
@@ -1,0 +1,4 @@
+package online.partyrun.partyrunbattleservice.domain.battle.event;
+
+public record BattleRunningEvent(String battleId) {
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/BattleRunningEvent.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/BattleRunningEvent.java
@@ -1,4 +1,3 @@
 package online.partyrun.partyrunbattleservice.domain.battle.event;
 
-public record BattleRunningEvent(String battleId) {
-}
+public record BattleRunningEvent(String battleId) {}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/RunnerRunningEvent.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/RunnerRunningEvent.java
@@ -1,7 +1,0 @@
-package online.partyrun.partyrunbattleservice.domain.battle.event;
-
-public record RunnerRunningEvent(String battleId, int targetCount) {
-    public boolean isTargetCount(int eventCount) {
-        return this.targetCount == eventCount;
-    }
-}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDao.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDao.java
@@ -3,8 +3,10 @@ package online.partyrun.partyrunbattleservice.domain.battle.repository;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
+
 import org.springframework.data.mongodb.core.FindAndModifyOptions;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
@@ -20,8 +22,7 @@ public class BattleDao {
     MongoTemplate mongoTemplate;
 
     public Battle updateRunnerStatus(String battleId, String runnerId, RunnerStatus runnerStatus) {
-        Query query =
-                Query.query(Criteria.where("id").is(battleId).and("runners.id").is(runnerId));
+        Query query = Query.query(Criteria.where("id").is(battleId).and("runners.id").is(runnerId));
         Update update = new Update().set("runners.$.status", runnerStatus);
 
         FindAndModifyOptions options = new FindAndModifyOptions().returnNew(true);

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDao.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDao.java
@@ -1,0 +1,31 @@
+package online.partyrun.partyrunbattleservice.domain.battle.repository;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
+import org.springframework.data.mongodb.core.FindAndModifyOptions;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class BattleDao {
+
+    MongoTemplate mongoTemplate;
+
+    public Battle updateRunnerStatus(String battleId, String runnerId, RunnerStatus runnerStatus) {
+        Query query =
+                Query.query(Criteria.where("id").is(battleId).and("runners.id").is(runnerId));
+        Update update = new Update().set("runners.$.status", runnerStatus);
+
+        FindAndModifyOptions options = new FindAndModifyOptions().returnNew(true);
+
+        return mongoTemplate.findAndModify(query, update, options, Battle.class);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -3,6 +3,7 @@ package online.partyrun.partyrunbattleservice.domain.battle.service;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleMapper;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
@@ -18,6 +19,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.service.RunnerService;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
@@ -68,7 +70,8 @@ public class BattleService {
     public void setRunnerRunning(String battleId, String runnerId) {
         final Battle battle = findBattle(battleId);
         battle.changeRunnerStatus(runnerId, RunnerStatus.RUNNING);
-        final Battle updatedBattle = battleDao.updateRunnerStatus(battleId, runnerId, battle.getRunnerStatus(runnerId));
+        final Battle updatedBattle =
+                battleDao.updateRunnerStatus(battleId, runnerId, battle.getRunnerStatus(runnerId));
 
         publishBattleRunningEvent(updatedBattle);
     }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
@@ -15,10 +15,11 @@ import java.util.Objects;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Runner {
     String id;
-    RunnerStatus status = RunnerStatus.READY;
+    RunnerStatus status;
 
     public Runner(String id) {
         this.id = id;
+        this.status = RunnerStatus.READY;
     }
 
     public boolean hasId(String id) {
@@ -42,5 +43,9 @@ public class Runner {
         if (Objects.isNull(status) || status.isReady() || this.status.equals(status)) {
             throw new RunnerStatusCannotBeChangedException(status);
         }
+    }
+
+    public boolean isRunning() {
+        return this.status.isRunning();
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -1,6 +1,12 @@
 package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import lombok.extern.slf4j.Slf4j;
+
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
@@ -10,6 +16,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -25,10 +32,6 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Slf4j
 @Import({WebSocketTestConfiguration.class, TestTimeConfig.class})

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -1,12 +1,6 @@
 package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import lombok.extern.slf4j.Slf4j;
-
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
@@ -16,7 +10,6 @@ import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepository;
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -32,6 +25,10 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Slf4j
 @Import({WebSocketTestConfiguration.class, TestTimeConfig.class})
@@ -153,7 +150,7 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                         .isEqualTo(노준혁_response)
                         .isEqualTo(
                                 new BattleStartTimeResponse(
-                                        LocalDateTime.now(clock).plusSeconds(10)));
+                                        LocalDateTime.now(clock).plusSeconds(5)));
             }
         }
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
@@ -1,9 +1,12 @@
 package online.partyrun.partyrunbattleservice.domain.battle.entity;
 
+import static org.assertj.core.api.Assertions.*;
+
 import online.partyrun.partyrunbattleservice.domain.battle.exception.*;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerNotFoundException;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
@@ -11,8 +14,6 @@ import org.junit.jupiter.params.provider.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("Battle")
 class BattleTest {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
@@ -257,4 +257,40 @@ class BattleTest {
             }
         }
     }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 배틀의_러너들이_모두_RUNNING_상태인지_확인할_때 {
+
+        Runner 박성우 = new Runner("박성우");
+        Runner 노준혁 = new Runner("노준혁");
+        Battle 배틀 = new Battle(1000, List.of(박성우, 노준혁));
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 모두_맞다면 {
+
+            @Test
+            @DisplayName("true를 반환한다.")
+            void returnTrue() {
+                박성우.changeStatus(RunnerStatus.RUNNING);
+                노준혁.changeStatus(RunnerStatus.RUNNING);
+
+                assertThat(배틀.isAllRunnersRunningStatus()).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 한명이라도_아니라면 {
+
+            @Test
+            @DisplayName("true를 반환한다.")
+            void returnTrue() {
+                박성우.changeStatus(RunnerStatus.FINISHED);
+
+                assertThat(배틀.isAllRunnersRunningStatus()).isFalse();
+            }
+        }
+    }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
@@ -1,12 +1,9 @@
 package online.partyrun.partyrunbattleservice.domain.battle.entity;
 
-import static org.assertj.core.api.Assertions.*;
-
 import online.partyrun.partyrunbattleservice.domain.battle.exception.*;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerNotFoundException;
-
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.*;
@@ -14,6 +11,8 @@ import org.junit.jupiter.params.provider.*;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("Battle")
 class BattleTest {
@@ -256,21 +255,6 @@ class BattleTest {
                 assertThatThrownBy(() -> 배틀.getRunnerStatus(invalidRunnerId))
                         .isInstanceOf(RunnerNotFoundException.class);
             }
-        }
-    }
-
-    @Nested
-    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-    class 참여_러너의_인원을_찾을_떄 {
-
-        List<Runner> runners = List.of(박성우, 박현준);
-
-        @Test
-        @DisplayName("러너의 인원을 반환한다")
-        void returnNumberOfRunners() {
-            final Battle battle = new Battle(1000, runners);
-
-            assertThat(battle.getNumberOfRunners()).isEqualTo(runners.size());
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDaoTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDaoTest.java
@@ -1,25 +1,24 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 @DisplayName("BattleDao")
 @SpringBootTest
 class BattleDaoTest {
 
-    @Autowired
-    BattleDao battleDao;
+    @Autowired BattleDao battleDao;
 
-    @Autowired
-    BattleRepository battleRepository;
+    @Autowired BattleRepository battleRepository;
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -33,11 +32,11 @@ class BattleDaoTest {
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class 러너의_상태를_받으면 {
 
-
             @Test
             @DisplayName("배틀을 업데이트 후 반환한다.")
             void updateBattle() {
-                Battle battle = battleDao.updateRunnerStatus(배틀.getId(), 박성우.getId(), RunnerStatus.RUNNING);
+                Battle battle =
+                        battleDao.updateRunnerStatus(배틀.getId(), 박성우.getId(), RunnerStatus.RUNNING);
 
                 assertThat(battle.getRunnerStatus(박성우.getId())).isEqualTo(RunnerStatus.RUNNING);
             }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDaoTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDaoTest.java
@@ -1,0 +1,46 @@
+package online.partyrun.partyrunbattleservice.domain.battle.repository;
+
+import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("BattleDao")
+@SpringBootTest
+class BattleDaoTest {
+
+    @Autowired
+    BattleDao battleDao;
+
+    @Autowired
+    BattleRepository battleRepository;
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 러너의_상태를_update할_때 {
+        Runner 박성우 = new Runner("박성우");
+        Runner 박현준 = new Runner("박현준");
+        Runner 노준혁 = new Runner("노준혁");
+        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준, 노준혁)));
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 러너의_상태를_받으면 {
+
+
+            @Test
+            @DisplayName("배틀을 업데이트 후 반환한다.")
+            void updateBattle() {
+                Battle battle = battleDao.updateRunnerStatus(배틀.getId(), 박성우.getId(), RunnerStatus.RUNNING);
+
+                assertThat(battle.getRunnerStatus(박성우.getId())).isEqualTo(RunnerStatus.RUNNING);
+            }
+        }
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,15 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestApplicationContextConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
@@ -17,7 +7,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleStartTimeResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
-import online.partyrun.partyrunbattleservice.domain.battle.event.RunnerRunningEvent;
+import online.partyrun.partyrunbattleservice.domain.battle.event.BattleRunningEvent;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.BattleAlreadyFinishedException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.BattleNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.ReadyBattleNotFoundException;
@@ -26,7 +16,6 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -37,6 +26,15 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @SpringBootTest
 @Import({TestApplicationContextConfig.class, TestTimeConfig.class})
@@ -217,8 +215,8 @@ class BattleServiceTest {
                 battleService.setRunnerRunning(배틀.getId(), 박성우.getId());
                 battleService.setRunnerRunning(배틀.getId(), 노준혁.getId());
                 then(publisher)
-                        .should(times(2))
-                        .publishEvent(new RunnerRunningEvent(배틀.getId(), 배틀.getNumberOfRunners()));
+                        .should(times(1))
+                        .publishEvent(new BattleRunningEvent(배틀.getId()));
             }
         }
 
@@ -230,7 +228,7 @@ class BattleServiceTest {
             @DisplayName("BattleRunningEvent을 publish 하지 않는다.")
             void notPublish() {
                 battleService.setRunnerRunning(배틀.getId(), 노준혁.getId());
-                then(publisher).should(never()).publishEvent(any(RunnerRunningEvent.class));
+                then(publisher).should(never()).publishEvent(any(BattleRunningEvent.class));
             }
         }
     }
@@ -250,7 +248,7 @@ class BattleServiceTest {
             @DisplayName("배틀의 상태를 변경한다.")
             void throwException() {
                 final BattleStartTimeResponse response = battleService.setBattleRunning(배틀.getId());
-                final LocalDateTime startTime = LocalDateTime.now(clock).plusSeconds(10);
+                final LocalDateTime startTime = LocalDateTime.now(clock).plusSeconds(5);
 
                 final Battle 조회된_배틀 = battleRepository.findById(배틀.getId()).orElseThrow();
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,5 +1,15 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestApplicationContextConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
@@ -16,6 +26,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -26,15 +37,6 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 
 @SpringBootTest
 @Import({TestApplicationContextConfig.class, TestTimeConfig.class})
@@ -214,9 +216,7 @@ class BattleServiceTest {
             void publishEvent() {
                 battleService.setRunnerRunning(배틀.getId(), 박성우.getId());
                 battleService.setRunnerRunning(배틀.getId(), 노준혁.getId());
-                then(publisher)
-                        .should(times(1))
-                        .publishEvent(new BattleRunningEvent(배틀.getId()));
+                then(publisher).should(times(1)).publishEvent(new BattleRunningEvent(배틀.getId()));
             }
         }
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
@@ -1,12 +1,11 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerAlreadyFinishedException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerStatusCannotBeChangedException;
-
 import org.junit.jupiter.api.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @DisplayName("Runner")
 class RunnerTest {
@@ -110,6 +109,37 @@ class RunnerTest {
             @DisplayName("false를 반환한다.")
             void returnTrue() {
                 assertThat(박성우.hasId(id)).isFalse();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 러너의_상태가_RUNNING인지_확인할_때 {
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class RUNNING_이라면 {
+
+            @Test
+            @DisplayName("true를 반환한다.")
+            void returnTrue() {
+                박성우.changeStatus(RunnerStatus.RUNNING);
+
+                assertThat(박성우.isRunning()).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class RUNNING이_아니라면 {
+
+            @Test
+            @DisplayName("false를 반환한다.")
+            void returnFalse() {
+                박성우.changeStatus(RunnerStatus.FINISHED);
+
+                assertThat(박성우.isRunning()).isFalse();
             }
         }
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
@@ -1,11 +1,12 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
-import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerAlreadyFinishedException;
-import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerStatusCannotBeChangedException;
-import org.junit.jupiter.api.*;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerAlreadyFinishedException;
+import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerStatusCannotBeChangedException;
+
+import org.junit.jupiter.api.*;
 
 @DisplayName("Runner")
 class RunnerTest {


### PR DESCRIPTION
## 변경 사항
현재 러너가 RUNNING 상태로 변경될 때마다, 스프링 이벤트를 발행하고 있습니다.
따라서 ConcurrentHashMap으로 이벤트를 관리하고 있었습니다.
ConcurrentHashMap으로 관리하는 방법에서, 이벤트를 한 번만 날려서 이벤트를 바로 처리하는 로직으로 변경했습니다.


## 알아야할 사항
몽고 DB의 `findOneAndUpdate`와 `returnNewDocument` 필드를 사용하여 이벤트를 한 번만 발행하도록 수정 시도해보았습니다.
몽고 DB는 기본적으로 도큐먼트를 수정하는 요청 여러개가 동시에 들어올 때 순차적으로 실행됩니다.

현재 변경된 로직에서 `findOneAndUpdate`를 통해 러너의 상태를 update 하고, 반환합니다.
이때 `returnNewDociment` 설정을 true로 하여, 조회-수정-반환을 원자적으로 실행할 수 있도록 변경했습니다.

즉, 여러 스레드가 동시에 들어와도 조회-수정-반환이 원자적으로 실행되어, 결국 마지막으로 요청한 스레드에만 모든 러너가 RUNNING 상태인 Battle을 조회하게 됩니다.
이 Battle을 조회한 스레드만 Event를 발행하게 됩니다.

[동시성 이슈 해결기2](https://www.notion.so/seongwoo-memo/feat-mongoDB-2-e4f9687fb02f4154a2f53b0e2627797e?pvs=4)

## 테스트 방법

BattleServiceTest에 `러너의_상태를_RUNNING으로_변경할_때 모든_러너의_상태가_변경되었다면 BattleRunningEvent을 publish한다. `
테스트에서 이벤트가 한 번만 발행되는지 테스트를 진행했습니다.
