### PR TITLE
battle, runner 의 상태를 검증하는 로직을 변경한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
@@ -55,22 +55,15 @@ public class Battle {
     }
 
     public void changeRunnerRunningStatus(String runnerId) {
-        validateIsRunningStatus();
-        validateIsFinishedStatus();
+        validateIsNotReadyStatus();
 
         final Runner runner = findRunner(runnerId);
         runner.changeRunningStatus();
     }
 
-    private void validateIsRunningStatus() {
-        if (this.status.isRunning()) {
-            throw new BattleAlreadyRunningException(this.id);
-        }
-    }
-
-    private void validateIsFinishedStatus() {
-        if (this.status.isFinished()) {
-            throw new BattleAlreadyFinishedException(this.id);
+    private void validateIsNotReadyStatus() {
+        if (!this.status.isReady()) {
+            throw new BattleIsNotReadyException(this.id);
         }
     }
 
@@ -82,8 +75,7 @@ public class Battle {
     }
 
     public void changeBattleRunning(LocalDateTime now) {
-        validateIsRunningStatus();
-        validateIsFinishedStatus();
+        validateIsNotReadyStatus();
         validateAllRunnersRunning();
 
         this.status = BattleStatus.RUNNING;
@@ -107,11 +99,17 @@ public class Battle {
     }
 
     public void addRecords(String runnerId, List<GpsData> gpsData) {
-        validateIsFinishedStatus();
+        validateIsNotRunningStatus();
         validateGpsData(gpsData);
 
         final Runner runner = findRunner(runnerId);
         runner.addRecords(gpsData);
+    }
+
+    private void validateIsNotRunningStatus() {
+        if (!this.status.isRunning()) {
+            throw new BattleIsNotRunningException(this.id);
+        }
     }
 
     private void validateGpsData(List<GpsData> gpsData) {

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/BattleAlreadyFinishedException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/BattleAlreadyFinishedException.java
@@ -1,9 +1,0 @@
-package online.partyrun.partyrunbattleservice.domain.battle.exception;
-
-import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
-
-public class BattleAlreadyFinishedException extends BadRequestException {
-    public BattleAlreadyFinishedException(String battleId) {
-        super(String.format("%s의 battle은 이미 Finished 상태입니다.", battleId));
-    }
-}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/BattleAlreadyRunningException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/BattleAlreadyRunningException.java
@@ -1,9 +1,0 @@
-package online.partyrun.partyrunbattleservice.domain.battle.exception;
-
-import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
-
-public class BattleAlreadyRunningException extends BadRequestException {
-    public BattleAlreadyRunningException(String battleId) {
-        super(String.format("%s의 battle은 이미 Running 상태입니다.", battleId));
-    }
-}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/BattleIsNotReadyException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/BattleIsNotReadyException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunbattleservice.domain.battle.exception;
+
+import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
+
+public class BattleIsNotReadyException extends BadRequestException {
+    public BattleIsNotReadyException(String battleId) {
+        super(String.format("%s 배틀은 READY 상태가 아닙니다.", battleId));
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/BattleIsNotRunningException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/BattleIsNotRunningException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunbattleservice.domain.battle.exception;
+
+import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
+
+public class BattleIsNotRunningException extends BadRequestException {
+    public BattleIsNotRunningException(String battleId) {
+        super(String.format("%s 배틀은 Running 상태가 아닙니다.", battleId));
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
@@ -7,10 +7,7 @@ import lombok.experimental.FieldDefaults;
 
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
-import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidRecentRunnerRecordException;
-import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerAlreadyFinishedException;
-import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerAlreadyRunningException;
-import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotRunningException;
+import online.partyrun.partyrunbattleservice.domain.runner.exception.*;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,21 +35,14 @@ public class Runner {
     }
 
     public void changeRunningStatus() {
-        validateIsRunningStatus();
-        validateIsFinishedStatus();
+        validateIsNotReadyStatus();
 
         this.status = RunnerStatus.RUNNING;
     }
 
-    private void validateIsRunningStatus() {
-        if (status.isRunning()) {
-            throw new RunnerAlreadyRunningException(this.id);
-        }
-    }
-
-    private void validateIsFinishedStatus() {
-        if (this.status.isFinished()) {
-            throw new RunnerAlreadyFinishedException(this.id);
+    private void validateIsNotReadyStatus() {
+        if (!status.isReady()) {
+            throw new RunnerIsNotReadyException(this.id);
         }
     }
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/exception/RunnerAlreadyFinishedException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/exception/RunnerAlreadyFinishedException.java
@@ -1,9 +1,0 @@
-package online.partyrun.partyrunbattleservice.domain.runner.exception;
-
-import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
-
-public class RunnerAlreadyFinishedException extends BadRequestException {
-    public RunnerAlreadyFinishedException(String runnerId) {
-        super(String.format("%s의 runner는 이미 Finished 상태입니다.", runnerId));
-    }
-}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/exception/RunnerAlreadyRunningException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/exception/RunnerAlreadyRunningException.java
@@ -1,9 +1,0 @@
-package online.partyrun.partyrunbattleservice.domain.runner.exception;
-
-import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
-
-public class RunnerAlreadyRunningException extends BadRequestException {
-    public RunnerAlreadyRunningException(String runnerId) {
-        super(String.format("%s의 runner는 이미 Running 상태입니다.", runnerId));
-    }
-}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/exception/RunnerIsNotReadyException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/exception/RunnerIsNotReadyException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunbattleservice.domain.runner.exception;
+
+import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
+
+public class RunnerIsNotReadyException extends BadRequestException {
+    public RunnerIsNotReadyException(String runnerId) {
+        super(String.format("%s의 runner는 Ready 상태가 아닙니다.", runnerId));
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
@@ -1,5 +1,7 @@
 package online.partyrun.partyrunbattleservice.domain.battle.entity;
 
+import static org.assertj.core.api.Assertions.*;
+
 import online.partyrun.partyrunbattleservice.domain.battle.exception.*;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
@@ -7,6 +9,7 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataTimeException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerNotFoundException;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -14,8 +17,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("Battle")
 class BattleTest {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
@@ -1,7 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.entity;
 
-import static org.assertj.core.api.Assertions.*;
-
 import online.partyrun.partyrunbattleservice.domain.battle.exception.*;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
@@ -9,7 +7,6 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataTimeException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerNotFoundException;
-
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -17,6 +14,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("Battle")
 class BattleTest {
@@ -111,7 +110,7 @@ class BattleTest {
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        class 배틀이_RUNNING_상태라면 {
+        class 배틀이_READY_상태가_아니라면 {
 
             @Test
             @DisplayName("예외를 던진다.")
@@ -121,17 +120,8 @@ class BattleTest {
                 배틀.changeBattleRunning(LocalDateTime.now());
 
                 assertThatThrownBy(() -> 배틀.changeRunnerRunningStatus(박성우.getId()))
-                        .isInstanceOf(BattleAlreadyRunningException.class);
+                        .isInstanceOf(BattleIsNotReadyException.class);
             }
-        }
-
-        @Nested
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        class 배틀이_FINISHED_상태라면 {
-            @Disabled
-            @Test
-            @DisplayName("예외를 던진다.")
-            void throwException() {}
         }
     }
 
@@ -158,7 +148,7 @@ class BattleTest {
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        class 이미_Running_상태라면 {
+        class READY_상태가_아니라면 {
 
             @Test
             @DisplayName("예외를 던진다.")
@@ -167,18 +157,8 @@ class BattleTest {
 
                 배틀.changeBattleRunning(now);
                 assertThatThrownBy(() -> 배틀.changeBattleRunning(now))
-                        .isInstanceOf(BattleAlreadyRunningException.class);
+                        .isInstanceOf(BattleIsNotReadyException.class);
             }
-        }
-
-        @Nested
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        class 배틀이_FINISHED_상태라면 {
-
-            @Disabled
-            @Test
-            @DisplayName("예외를 던진다.")
-            void throwException() {}
         }
 
         @Nested
@@ -291,10 +271,14 @@ class BattleTest {
                     .isInstanceOf(InvalidGpsDataException.class);
         }
 
-        @Disabled
         @Test
-        @DisplayName("배틀이 이미 종료되었다면 예외를 던진다.")
-        void throwBattleAlreadyFinishedException() {}
+        @DisplayName("배틀이 RUNNING 상태가 아니라면 예외를 던진다..")
+        void throwBattleIsNotRunningException() {
+            노준혁 = new Runner("노준혁");
+            배틀 = new Battle(1000, List.of(노준혁));
+            assertThatThrownBy(() -> 배틀.addRecords(노준혁.getId(), List.of()))
+                    .isInstanceOf(BattleIsNotRunningException.class);
+        }
 
         @Test
         @DisplayName("GpsData가 배틀 시작 시간보다 이전에 생성되었다면 예외를 던진다.")

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
@@ -1,18 +1,19 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidRecentRunnerRecordException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotReadyException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotRunningException;
+
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Runner")
 class RunnerTest {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
@@ -1,19 +1,18 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidRecentRunnerRecordException;
-import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerAlreadyRunningException;
+import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotReadyException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotRunningException;
-
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Runner")
 class RunnerTest {
@@ -38,14 +37,14 @@ class RunnerTest {
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        class 변경할_상태가_이미_RUNNING_상태라면 {
+        class READY_상태가_아니라면 {
 
             @Test
             @DisplayName("예외를 던진다")
             void throwException() {
                 박성우.changeRunningStatus();
                 assertThatThrownBy(() -> 박성우.changeRunningStatus())
-                        .isInstanceOf(RunnerAlreadyRunningException.class);
+                        .isInstanceOf(RunnerIsNotReadyException.class);
             }
         }
     }


### PR DESCRIPTION
## 변경 사항
아침에 말했던 대로 원하는 상태만을 검증하도록 변경했습니다.
만약에 특정 메소드를 실행할 때 `READY` 상태여야한다면, `READY` 상태인지 아닌지에 대해서만 검증하도록 변경했습니다.

이를 통해 기존에 `@Disable`로 처리했던 테스트 코드를 제거하고 테스트 커버리지를 채울 수 있게 되었습니다.


