### PR TITLE
러너들에게 좌표를 받고, 목표 거리에 도달 시 러너가 종료 상태가 되도록 변경한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
@@ -145,4 +145,10 @@ public class Battle {
 
         return runner.getRecentDistance();
     }
+
+    public boolean isRunnerFinished(String runnerId) {
+        final Runner runner = findRunner(runnerId);
+
+        return runner.isFinished();
+    }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
@@ -104,6 +104,8 @@ public class Battle {
 
         final Runner runner = findRunner(runnerId);
         runner.addRecords(gpsData);
+
+        changeFinishStatusIfExceededTargetDistance(runner);
     }
 
     private void validateIsNotRunningStatus() {
@@ -119,6 +121,12 @@ public class Battle {
 
         if (hasBeforeStartTime(gpsData)) {
             throw new InvalidGpsDataTimeException(this.startTime);
+        }
+    }
+
+    private void changeFinishStatusIfExceededTargetDistance(Runner runner) {
+        if (runner.isRunningMoreThan(this.targetDistance)) {
+            runner.changeFinishStatus();
         }
     }
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -5,6 +5,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
+
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.Update;
@@ -23,6 +24,12 @@ public interface BattleRepository extends MongoRepository<Battle, String> {
     Optional<Battle> findBattleExceptRunnerRecords(String battleId, String runnerId);
 
     @Query(value = "{'id': ?0, 'runners.id': ?1}")
-    @Update("{'$push': {'runners.$.runnerRecords': {'$each': ?2}}, '$set' :  {'runners.$.status':  ?3}}")
-    void addRunnerRecordsAndUpdateRunnerStatus(String battleId, String runnerId, List<RunnerRecord> runnerRecords, RunnerStatus runnerStatus);
+    @Update(
+            "{'$push': {'runners.$.runnerRecords': {'$each': ?2}}, '$set' :  {'runners.$.status': "
+                + " ?3}}")
+    void addRunnerRecordsAndUpdateRunnerStatus(
+            String battleId,
+            String runnerId,
+            List<RunnerRecord> runnerRecords,
+            RunnerStatus runnerStatus);
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -3,8 +3,8 @@ package online.partyrun.partyrunbattleservice.domain.battle.repository;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
-
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.data.mongodb.repository.Query;
 import org.springframework.data.mongodb.repository.Update;
@@ -23,6 +23,6 @@ public interface BattleRepository extends MongoRepository<Battle, String> {
     Optional<Battle> findBattleExceptRunnerRecords(String battleId, String runnerId);
 
     @Query(value = "{'id': ?0, 'runners.id': ?1}")
-    @Update("{'$push': {'runners.$.runnerRecords': {'$each': ?2}}}")
-    void addRunnerRecords(String battleId, String runnerId, List<RunnerRecord> runnerRecords);
+    @Update("{'$push': {'runners.$.runnerRecords': {'$each': ?2}}, '$set' :  {'runners.$.status':  ?3}}")
+    void addRunnerRecordsAndUpdateRunnerStatus(String battleId, String runnerId, List<RunnerRecord> runnerRecords, RunnerStatus runnerStatus);
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -101,6 +101,7 @@ public class BattleService {
 
         final List<GpsData> gpsData = createGpsData(request);
         battle.addRecords(runnerId, gpsData);
+        // TODO: 2023/07/29 addRunnerRecord시 기록 + Runner의 상태 push
         battleRepository.addRunnerRecords(
                 battle.getId(), runnerId, battle.getRunnerRecords(runnerId));
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -101,13 +101,9 @@ public class BattleService {
 
         final List<GpsData> gpsData = createGpsData(request);
         battle.addRecords(runnerId, gpsData);
-        // TODO: 2023/07/29 addRunnerRecord시 기록 + Runner의 상태 push
-        battleRepository.addRunnerRecords(
-                battle.getId(), runnerId, battle.getRunnerRecords(runnerId));
+        battleRepository.addRunnerRecordsAndUpdateRunnerStatus(battleId, runnerId, battle.getRunnerRecords(runnerId), battle.getRunnerStatus(runnerId));
 
-        // TODO: 2023/07/21 현재는 종료 로직이 들어가지 않았으므로 무조건 isFinished에 false 적용
-        return new RunnerDistanceResponse(
-                runnerId, false, battle.getRunnerRecentDistance(runnerId));
+        return new RunnerDistanceResponse(runnerId, false, battle.getRunnerRecentDistance(runnerId));
     }
 
     private Battle findBattleExceptRunnerRecords(String battleId, String runnerId) {

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -101,9 +101,16 @@ public class BattleService {
 
         final List<GpsData> gpsData = createGpsData(request);
         battle.addRecords(runnerId, gpsData);
-        battleRepository.addRunnerRecordsAndUpdateRunnerStatus(battleId, runnerId, battle.getRunnerRecords(runnerId), battle.getRunnerStatus(runnerId));
+        battleRepository.addRunnerRecordsAndUpdateRunnerStatus(
+                battleId,
+                runnerId,
+                battle.getRunnerRecords(runnerId),
+                battle.getRunnerStatus(runnerId));
 
-        return new RunnerDistanceResponse(runnerId, battle.isRunnerFinished(runnerId), battle.getRunnerRecentDistance(runnerId));
+        return new RunnerDistanceResponse(
+                runnerId,
+                battle.isRunnerFinished(runnerId),
+                battle.getRunnerRecentDistance(runnerId));
     }
 
     private Battle findBattleExceptRunnerRecords(String battleId, String runnerId) {

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -103,7 +103,7 @@ public class BattleService {
         battle.addRecords(runnerId, gpsData);
         battleRepository.addRunnerRecordsAndUpdateRunnerStatus(battleId, runnerId, battle.getRunnerRecords(runnerId), battle.getRunnerStatus(runnerId));
 
-        return new RunnerDistanceResponse(runnerId, false, battle.getRunnerRecentDistance(runnerId));
+        return new RunnerDistanceResponse(runnerId, battle.isRunnerFinished(runnerId), battle.getRunnerRecentDistance(runnerId));
     }
 
     private Battle findBattleExceptRunnerRecords(String battleId, String runnerId) {

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
@@ -50,6 +50,10 @@ public class Runner {
         return this.status.isRunning();
     }
 
+    public boolean isFinished() {
+        return this.status.isFinished();
+    }
+
     public void addRecords(List<GpsData> gpsData) {
         validateIsNotRunningStatus();
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
@@ -99,4 +99,14 @@ public class Runner {
             throw new InvalidRecentRunnerRecordException(this.id);
         }
     }
+
+    public boolean isRunningMoreThan(int targetDistance) {
+        return this.recentRunnerRecord.hasBiggerDistanceThan(targetDistance);
+    }
+
+    public void changeFinishStatus() {
+        validateIsNotRunningStatus();
+
+        this.status = RunnerStatus.FINISHED;
+    }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/RunnerRecord.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/RunnerRecord.java
@@ -44,6 +44,10 @@ public class RunnerRecord implements Comparable<RunnerRecord> {
         return new RunnerRecord(gpsData, this.distance + distance);
     }
 
+    public boolean hasBiggerDistanceThan(int targetDistance) {
+        return this.distance > targetDistance;
+    }
+
     @Override
     public int compareTo(RunnerRecord o) {
         return this.gpsData.compareTo(o.gpsData);

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
@@ -1,5 +1,7 @@
 package online.partyrun.partyrunbattleservice.domain.battle.entity;
 
+import static org.assertj.core.api.Assertions.*;
+
 import online.partyrun.partyrunbattleservice.domain.battle.exception.*;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
@@ -7,6 +9,7 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataTimeException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerNotFoundException;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -14,8 +17,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("Battle")
 class BattleTest {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
@@ -1,7 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.entity;
 
-import static org.assertj.core.api.Assertions.*;
-
 import online.partyrun.partyrunbattleservice.domain.battle.exception.*;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
@@ -9,7 +7,6 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataTimeException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerNotFoundException;
-
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -17,6 +14,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("Battle")
 class BattleTest {
@@ -191,6 +190,50 @@ class BattleTest {
             RunnerStatus runnerStatus = 배틀.getRunnerStatus(박성우.getId());
 
             assertThat(runnerStatus).isEqualTo(박성우.getStatus());
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 존재하지_않는_러너라면 {
+
+            String invalidRunnerId = "invalidRunnerId";
+
+            @Test
+            @DisplayName("예외를 던진다")
+            void throwException() {
+                assertThatThrownBy(() -> 배틀.getRunnerStatus(invalidRunnerId))
+                        .isInstanceOf(RunnerNotFoundException.class);
+            }
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 러너의_종료_여부를_찾을_때 {
+
+        @BeforeEach
+        void setUp() {
+            박성우 = new Runner("박성우");
+            배틀 = new Battle(1000, List.of(박성우));
+        }
+
+        @Test
+        @DisplayName("종료 상태라면 True를 반환한다.")
+        void returnIsRunnerFinished() {
+            박성우.changeRunningStatus();
+            박성우.changeFinishStatus();
+
+            boolean actual = 배틀.isRunnerFinished(박성우.getId());
+
+            assertThat(actual).isTrue();
+        }
+
+        @Test
+        @DisplayName("종료 상태가 아니면 False를 반환한다.")
+        void returnIsNotRunnerFinished() {
+            boolean actual = 배틀.isRunnerFinished(박성우.getId());
+
+            assertThat(actual).isFalse();
         }
 
         @Nested

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -3,6 +3,7 @@ package online.partyrun.partyrunbattleservice.domain.battle.repository;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
 import org.junit.jupiter.api.*;
@@ -168,15 +169,18 @@ class BattleRepositoryTest {
         @Test
         @DisplayName("battleId, ruunerId, 새로운 기록을 입력받으면 runner에게 해당 기록을 저장한다.")
         void addRunnerNewRecords() {
-            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(배틀.getId(), 박성우.getId(), runnerRecords1, 박성우.getStatus());
-            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(배틀.getId(), 박성우.getId(), runnerRecords2, 박성우.getStatus());
-            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(배틀.getId(), 박현준.getId(), runnerRecords1, 박현준.getStatus());
+            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(배틀.getId(), 박성우.getId(), runnerRecords1, RunnerStatus.RUNNING);
+            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(배틀.getId(), 박성우.getId(), runnerRecords2, RunnerStatus.FINISHED);
+            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(배틀.getId(), 박현준.getId(), runnerRecords1, RunnerStatus.RUNNING);
 
             Battle battle = battleRepository.findById(배틀.getId()).orElseThrow();
 
             Assertions.assertAll(
                     () -> assertThat(battle.getRunnerRecords(박성우.getId())).hasSize(4),
-                    () -> assertThat(battle.getRunnerRecords(박현준.getId())).hasSize(2));
+                    () -> assertThat(battle.isRunnerFinished(박성우.getId())).isTrue(),
+                    () -> assertThat(battle.getRunnerRecords(박현준.getId())).hasSize(2),
+                    () -> assertThat(battle.isRunnerFinished(박현준.getId())).isFalse()
+            );
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,11 +1,15 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -14,9 +18,6 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataMongoTest
 @DisplayName("BattleRepository")
@@ -169,9 +170,12 @@ class BattleRepositoryTest {
         @Test
         @DisplayName("battleId, ruunerId, 새로운 기록을 입력받으면 runner에게 해당 기록을 저장한다.")
         void addRunnerNewRecords() {
-            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(배틀.getId(), 박성우.getId(), runnerRecords1, RunnerStatus.RUNNING);
-            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(배틀.getId(), 박성우.getId(), runnerRecords2, RunnerStatus.FINISHED);
-            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(배틀.getId(), 박현준.getId(), runnerRecords1, RunnerStatus.RUNNING);
+            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(
+                    배틀.getId(), 박성우.getId(), runnerRecords1, RunnerStatus.RUNNING);
+            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(
+                    배틀.getId(), 박성우.getId(), runnerRecords2, RunnerStatus.FINISHED);
+            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(
+                    배틀.getId(), 박현준.getId(), runnerRecords1, RunnerStatus.RUNNING);
 
             Battle battle = battleRepository.findById(배틀.getId()).orElseThrow();
 
@@ -179,8 +183,7 @@ class BattleRepositoryTest {
                     () -> assertThat(battle.getRunnerRecords(박성우.getId())).hasSize(4),
                     () -> assertThat(battle.isRunnerFinished(박성우.getId())).isTrue(),
                     () -> assertThat(battle.getRunnerRecords(박현준.getId())).hasSize(2),
-                    () -> assertThat(battle.isRunnerFinished(박현준.getId())).isFalse()
-            );
+                    () -> assertThat(battle.isRunnerFinished(박현준.getId())).isFalse());
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,14 +1,10 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.BattleStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -17,6 +13,9 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataMongoTest
 @DisplayName("BattleRepository")
@@ -154,7 +153,8 @@ class BattleRepositoryTest {
 
         @BeforeEach
         void setUp() {
-            배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준)));
+            int targetDistance = 100000;
+            배틀 = battleRepository.save(new Battle(targetDistance, List.of(박성우, 박현준)));
         }
 
         LocalDateTime now = LocalDateTime.now();
@@ -168,10 +168,9 @@ class BattleRepositoryTest {
         @Test
         @DisplayName("battleId, ruunerId, 새로운 기록을 입력받으면 runner에게 해당 기록을 저장한다.")
         void addRunnerNewRecords() {
-            battleRepository.addRunnerRecords(배틀.getId(), 박성우.getId(), runnerRecords1);
-            battleRepository.addRunnerRecords(배틀.getId(), 박성우.getId(), runnerRecords2);
-
-            battleRepository.addRunnerRecords(배틀.getId(), 박현준.getId(), runnerRecords1);
+            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(배틀.getId(), 박성우.getId(), runnerRecords1, 박성우.getStatus());
+            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(배틀.getId(), 박성우.getId(), runnerRecords2, 박성우.getStatus());
+            battleRepository.addRunnerRecordsAndUpdateRunnerStatus(배틀.getId(), 박현준.getId(), runnerRecords1, 박현준.getStatus());
 
             Battle battle = battleRepository.findById(배틀.getId()).orElseThrow();
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,5 +1,15 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestApplicationContextConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
@@ -13,6 +23,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -24,32 +35,17 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-
 @SpringBootTest
 @Import({TestApplicationContextConfig.class, TestTimeConfig.class})
 @DisplayName("BattleService")
 class BattleServiceTest {
 
-    @Autowired
-    BattleService battleService;
-    @Autowired
-    BattleRepository battleRepository;
-    @Autowired
-    MemberRepository memberRepository;
-    @Autowired
-    MongoTemplate mongoTemplate;
-    @Autowired
-    ApplicationEventPublisher publisher;
-    @Autowired
-    Clock clock;
+    @Autowired BattleService battleService;
+    @Autowired BattleRepository battleRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired MongoTemplate mongoTemplate;
+    @Autowired ApplicationEventPublisher publisher;
+    @Autowired Clock clock;
 
     @AfterEach
     void setUp() {
@@ -104,14 +100,14 @@ class BattleServiceTest {
                 battleService.createBattle(request);
 
                 assertThatThrownBy(
-                        () ->
-                                battleService.createBattle(
-                                        new BattleCreateRequest(
-                                                1000,
-                                                List.of(
-                                                        박성우.getId(),
-                                                        장세연.getId(),
-                                                        이승열.getId()))))
+                                () ->
+                                        battleService.createBattle(
+                                                new BattleCreateRequest(
+                                                        1000,
+                                                        List.of(
+                                                                박성우.getId(),
+                                                                장세연.getId(),
+                                                                이승열.getId()))))
                         .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
             }
         }
@@ -169,12 +165,12 @@ class BattleServiceTest {
                 battleService.setRunnerRunning(배틀.getId(), 박성우.getId());
 
                 assertThat(
-                        battleRepository
-                                .findById(배틀.getId())
-                                .orElseThrow()
-                                .getRunners()
-                                .get(0)
-                                .getStatus())
+                                battleRepository
+                                        .findById(배틀.getId())
+                                        .orElseThrow()
+                                        .getRunners()
+                                        .get(0)
+                                        .getStatus())
                         .isEqualTo(RunnerStatus.RUNNING);
             }
         }
@@ -189,7 +185,7 @@ class BattleServiceTest {
             @DisplayName("예외를 던진다.")
             void throwException() {
                 assertThatThrownBy(
-                        () -> battleService.setRunnerRunning(invalidBattleId, 박성우.getId()))
+                                () -> battleService.setRunnerRunning(invalidBattleId, 박성우.getId()))
                         .isInstanceOf(BattleNotFoundException.class);
             }
         }
@@ -308,15 +304,16 @@ class BattleServiceTest {
             }
         }
 
-
         @Test
         @DisplayName("목표 거리를 다 안달렸다면 진행중이라는 정보를 제공한다.")
         void returnRunnerIsNotFinished() {
             GpsRequest gps_request1 = new GpsRequest(0, 0, 0, now);
             GpsRequest gps_request2 = new GpsRequest(0.006, 0.006, 0, now.plusSeconds(1));
-            RunnerRecordRequest request = new RunnerRecordRequest(List.of(gps_request1, gps_request2));
+            RunnerRecordRequest request =
+                    new RunnerRecordRequest(List.of(gps_request1, gps_request2));
 
-            RunnerDistanceResponse response = battleService.calculateDistance(진행중인_배틀.getId(), 박성우.getId(), request);
+            RunnerDistanceResponse response =
+                    battleService.calculateDistance(진행중인_배틀.getId(), 박성우.getId(), request);
 
             assertThat(response.isFinished()).isFalse();
         }
@@ -326,19 +323,22 @@ class BattleServiceTest {
         void returnRunnerIsFinished() {
             GpsRequest gps_request1 = new GpsRequest(0, 0, 0, now);
             GpsRequest gps_request2 = new GpsRequest(0.007, 0.007, 0, now.plusSeconds(1));
-            RunnerRecordRequest request = new RunnerRecordRequest(List.of(gps_request1, gps_request2));
+            RunnerRecordRequest request =
+                    new RunnerRecordRequest(List.of(gps_request1, gps_request2));
 
-            RunnerDistanceResponse response = battleService.calculateDistance(진행중인_배틀.getId(), 박성우.getId(), request);
+            RunnerDistanceResponse response =
+                    battleService.calculateDistance(진행중인_배틀.getId(), 박성우.getId(), request);
 
             assertThat(response.isFinished()).isTrue();
         }
+
         @Test
         @DisplayName("배틀을 조회하지 못하면 예외를 던진다.")
         void throwException() {
             assertThatThrownBy(
-                    () ->
-                            battleService.calculateDistance(
-                                    "invalidBattleId", 박성우.getId(), RECORD_REQUEST1))
+                            () ->
+                                    battleService.calculateDistance(
+                                            "invalidBattleId", 박성우.getId(), RECORD_REQUEST1))
                     .isInstanceOf(BattleNotFoundException.class);
         }
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
@@ -1,18 +1,19 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidRecentRunnerRecordException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotReadyException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotRunningException;
+
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Runner")
 class RunnerTest {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
@@ -1,19 +1,18 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidRecentRunnerRecordException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotReadyException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotRunningException;
-
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Runner")
 class RunnerTest {
@@ -104,6 +103,36 @@ class RunnerTest {
             @DisplayName("false를 반환한다.")
             void returnFalse() {
                 assertThat(박성우.isRunning()).isFalse();
+            }
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 러너의_상태가_FINISHED인지_확인할_때 {
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class FINISHED_이라면 {
+
+            @Test
+            @DisplayName("true를 반환한다.")
+            void returnTrue() {
+                박성우.changeRunningStatus();
+                박성우.changeFinishStatus();
+
+                assertThat(박성우.isFinished()).isTrue();
+            }
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class FINISHED가_아니라면 {
+
+            @Test
+            @DisplayName("false를 반환한다.")
+            void returnFalse() {
+                assertThat(박성우.isFinished()).isFalse();
             }
         }
     }


### PR DESCRIPTION
## 변경 사항
이전까지는 좌표를 추가할 때, 목표 거리를 다 달렸는지에 대해서는 확인하지 않았습니다.

이번 PR에서는 좌표를 추가하는 시점에, 목표 거리를 다 달렸다면 러너의 상태를 Finished로 변경하였습니다.
Finished 상태로 변경된 러너는, 더이상 좌표를 추가할 수 없습니다.
즉, 배틀에 더이상 참여할 수 없습니다.

## 알아야할 사항
로직적으로 크게 어려운 부분은 없습니다. 

battleRepository의 addRunnerRecordsAndUpdateRunnerStatus 메서드를 통해 좌표를 추가하는 시점에 runner의 상태도 같이 업데이트 합니다. 
runner 가 running 상태일 때는 굳이 update를 진행할 필요가 없습니다. 따라서 service에서 runner가 running 상태라면 addRunnerRecords를 실행하고, finished 상태라면 addRunnerRecordsAndUpdateRunnerStatus를 실행하도록 해야할까요?

아니면 그냥 지금처럼 단순하게 addRunnerRecordsAndUpdateRunnerStatus만 사용하도록 할까요?
