### PR TITLE
 spring security에 의해 rest docs 문서가 접근 불가능하던 문제 해결

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
@@ -15,6 +15,7 @@ public class BattleAuthorizationRegistry implements AuthorizationRegistry {
                     AuthorizeHttpRequestsConfigurer<HttpSecurity>
                                     .AuthorizationManagerRequestMatcherRegistry
                             r) {
-        return r.requestMatchers("/battle").hasRole("SYSTEM").anyRequest().hasRole("USER");
+        return r.requestMatchers("/docs/index.html").permitAll()
+                .requestMatchers("/battle").hasRole("SYSTEM").anyRequest().hasRole("USER");
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/config/BattleAuthorizationRegistry.java
@@ -15,7 +15,11 @@ public class BattleAuthorizationRegistry implements AuthorizationRegistry {
                     AuthorizeHttpRequestsConfigurer<HttpSecurity>
                                     .AuthorizationManagerRequestMatcherRegistry
                             r) {
-        return r.requestMatchers("/docs/index.html").permitAll()
-                .requestMatchers("/battle").hasRole("SYSTEM").anyRequest().hasRole("USER");
+        return r.requestMatchers("/docs/index.html")
+                .permitAll()
+                .requestMatchers("/battle")
+                .hasRole("SYSTEM")
+                .anyRequest()
+                .hasRole("USER");
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,10 @@ server:
   servlet:
     context-path: /api
 
+auth:
+  filter:
+    exclusions: "/docs/index.html"
+
 spring:
   profiles:
     active: test


### PR DESCRIPTION
## 변경 사항
도커 이미지 빌드 시에 rest docs 문서가 안나오는 문제를 해결하려다가..
애초에 rest docs에는 접근 불가능했다라는 것을 발견했습니다.

`spring security`에 의해서 /api/docs/index.html 에 접근할 수 없었습니다.
matching 도 마찬가지로 403 에러가 뜰 것입니다. 이는 추후에 확인해보겠습니다.
이를 해결하기 위해 spring security 라이브러리에서 만든 필터에 url 을 추가하고
해당 url로 접근 시, 모두 허가되도록 구현하였습니다.
