### PR TITLE
배틀 웹소켓 통신 과정 중, 발생하는 예외를 처리한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleMessageControllerAdvice.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleMessageControllerAdvice.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.ControllerAdvice;
 @Slf4j
 @ControllerAdvice
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
-public class BattleMessageExceptionHandler {
+public class BattleMessageControllerAdvice {
 
     @MessageExceptionHandler
     public void handleException(Exception exception) {

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleMessageExceptionHandler.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleMessageExceptionHandler.java
@@ -1,9 +1,9 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
-
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleMessageExceptionHandler.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleMessageExceptionHandler.java
@@ -1,0 +1,19 @@
+package online.partyrun.partyrunbattleservice.domain.battle.controller;
+
+
+import lombok.AccessLevel;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+
+@Slf4j
+@ControllerAdvice
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class BattleMessageExceptionHandler {
+
+    @MessageExceptionHandler
+    public void handleException(Exception exception) {
+        log.warn(exception.getMessage());
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/GpsData.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/GpsData.java
@@ -5,9 +5,9 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
 import online.partyrun.partyrunbattleservice.domain.runner.exception.GpsTimeNullException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
+import online.partyrun.partyrunbattleservice.domain.runner.exception.PastGpsDataTimeException;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -38,12 +38,19 @@ public class GpsData implements Comparable<GpsData> {
 
     public double calculateDistance(GpsData other) {
         validateNull(other);
+        validateIsBeforeData(other.time);
         return this.location.calculateDistance(other.location, new HaversineDistanceCalculator());
     }
 
     private void validateNull(GpsData other) {
         if (Objects.isNull(other)) {
             throw new InvalidGpsDataException();
+        }
+    }
+
+    private void validateIsBeforeData(LocalDateTime time) {
+        if (this.time.isAfter(time)) {
+            throw new PastGpsDataTimeException(this.time, time);
         }
     }
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/GpsData.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/GpsData.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunbattleservice.domain.runner.exception.GpsTimeNullException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.PastGpsDataTimeException;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/exception/PastGpsDataTimeException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/exception/PastGpsDataTimeException.java
@@ -1,0 +1,11 @@
+package online.partyrun.partyrunbattleservice.domain.runner.exception;
+
+import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
+
+import java.time.LocalDateTime;
+
+public class PastGpsDataTimeException extends BadRequestException {
+    public PastGpsDataTimeException(LocalDateTime recentDataTime, LocalDateTime gpsDataTime) {
+        super(String.format("추가될 GpsData 시간 %s 는 최근 GpsData 시간 %s 보다 같거나 이후여야 합니다.", gpsDataTime, recentDataTime));
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/exception/PastGpsDataTimeException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/exception/PastGpsDataTimeException.java
@@ -6,6 +6,9 @@ import java.time.LocalDateTime;
 
 public class PastGpsDataTimeException extends BadRequestException {
     public PastGpsDataTimeException(LocalDateTime recentDataTime, LocalDateTime gpsDataTime) {
-        super(String.format("추가될 GpsData 시간 %s 는 최근 GpsData 시간 %s 보다 같거나 이후여야 합니다.", gpsDataTime, recentDataTime));
+        super(
+                String.format(
+                        "추가될 GpsData 시간 %s 는 최근 GpsData 시간 %s 보다 같거나 이후여야 합니다.",
+                        gpsDataTime, recentDataTime));
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/GpsDataTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/GpsDataTest.java
@@ -1,15 +1,16 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity.record;
 
-import online.partyrun.partyrunbattleservice.domain.runner.exception.GpsTimeNullException;
-import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
-import online.partyrun.partyrunbattleservice.domain.runner.exception.PastGpsDataTimeException;
-import org.junit.jupiter.api.*;
-
-import java.time.LocalDateTime;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
+
+import online.partyrun.partyrunbattleservice.domain.runner.exception.GpsTimeNullException;
+import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
+import online.partyrun.partyrunbattleservice.domain.runner.exception.PastGpsDataTimeException;
+
+import org.junit.jupiter.api.*;
+
+import java.time.LocalDateTime;
 
 @DisplayName("GpsData")
 class GpsDataTest {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/GpsDataTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/GpsDataTest.java
@@ -1,15 +1,15 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity.record;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunbattleservice.domain.runner.exception.GpsTimeNullException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
-
+import online.partyrun.partyrunbattleservice.domain.runner.exception.PastGpsDataTimeException;
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("GpsData")
 class GpsDataTest {
@@ -27,6 +27,13 @@ class GpsDataTest {
         void throwNullException() {
             assertThatThrownBy(() -> GPSDATA_0.calculateDistance(null))
                     .isInstanceOf(InvalidGpsDataException.class);
+        }
+
+        @Test
+        @DisplayName("과거 시간의 데이터와 비교시 예외를 던진다.")
+        void throwPastDataException() {
+            assertThatThrownBy(() -> GPSDATA_1.calculateDistance(GPSDATA_0))
+                    .isInstanceOf(PastGpsDataTimeException.class);
         }
 
         @Test


### PR DESCRIPTION
## 변경 사항

@ControllerAdvice를 추가했습니다.
클라이언트와의 통신 과정 중, 예외에 대해서 로그를 찍지 않아서 빠르게 확인할 수 없는 문제가 있었습니다.
이를 해결하기 위한 방법으로  간단하게 ExceptionHandler를 구현했습니다.

추가로 에러 핸들러가 잘 동작하는지 확인하다가 새로운 검증 로직이 발견되어서 간단하게 추가해보았습니다.

## 알아야할 사항
현재는 log를 찍는 용도로만 사용하지만, 추후에는 유저에게 직접 에러 메시지를 전달하여, 웹소켓 연결을 끊는 작업을 유도할 것 입니다.
