### PR TITLE
@CreatedDate를 삭제한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
@@ -1,22 +1,15 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
 import jakarta.validation.Valid;
-
 import lombok.AccessLevel;
-import lombok.Generated;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-
-import java.time.Clock;
-import java.time.LocalDateTime;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,7 +18,6 @@ import java.time.LocalDateTime;
 public class BattleController {
 
     BattleService battleService;
-    Clock clock;
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
@@ -38,12 +30,5 @@ public class BattleController {
     @ResponseStatus(HttpStatus.OK)
     public BattleResponse getReadyBattle(Authentication auth) {
         return battleService.getReadyBattle(auth.getName());
-    }
-
-    @Generated
-    @GetMapping("clock")
-    @ResponseStatus(HttpStatus.OK)
-    public LocalDateTime returnClock() {
-        return LocalDateTime.now(clock);
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
@@ -1,12 +1,15 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
 import jakarta.validation.Valid;
+
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
@@ -4,6 +4,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunbattleservice.domain.battle.exception.*;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
@@ -12,6 +13,7 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerR
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataTimeException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerNotFoundException;
+
 import org.springframework.data.annotation.Id;
 
 import java.time.LocalDateTime;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/entity/Battle.java
@@ -4,7 +4,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
 import online.partyrun.partyrunbattleservice.domain.battle.exception.*;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
@@ -13,8 +12,6 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerR
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataTimeException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerNotFoundException;
-
-import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
 
 import java.time.LocalDateTime;
@@ -32,13 +29,21 @@ public class Battle {
     int targetDistance;
     List<Runner> runners;
     LocalDateTime startTime;
-    @CreatedDate LocalDateTime createdAt;
+    LocalDateTime createdAt;
 
-    public Battle(int targetDistance, List<Runner> runners) {
+    public Battle(int targetDistance, List<Runner> runners, LocalDateTime createdAt) {
         validateDistance(targetDistance);
         validateRunners(runners);
+        validateCreatedAt(createdAt);
         this.targetDistance = targetDistance;
         this.runners = runners;
+        this.createdAt = createdAt;
+    }
+
+    private void validateCreatedAt(LocalDateTime createdAt) {
+        if (Objects.isNull(createdAt)) {
+            throw new InvalidBattleCreatedAtException();
+        }
     }
 
     private void validateDistance(int distance) {

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/InvalidBattleCreatedAtException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/exception/InvalidBattleCreatedAtException.java
@@ -1,0 +1,10 @@
+package online.partyrun.partyrunbattleservice.domain.battle.exception;
+
+import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
+
+public class InvalidBattleCreatedAtException extends BadRequestException {
+
+    public InvalidBattleCreatedAtException() {
+        super("배틀 생성 시간은 null일 수 없습니다.");
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -42,7 +42,7 @@ public class BattleService {
         validateRunningRunner(runnerIds);
         final List<Runner> runners = runnerService.findAllById(runnerIds);
 
-        final Battle battle = battleRepository.save(new Battle(request.getDistance(), runners));
+        final Battle battle = battleRepository.save(new Battle(request.getDistance(), runners, LocalDateTime.now(clock)));
         return battleMapper.toResponse(battle);
     }
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -42,7 +42,9 @@ public class BattleService {
         validateRunningRunner(runnerIds);
         final List<Runner> runners = runnerService.findAllById(runnerIds);
 
-        final Battle battle = battleRepository.save(new Battle(request.getDistance(), runners, LocalDateTime.now(clock)));
+        final Battle battle =
+                battleRepository.save(
+                        new Battle(request.getDistance(), runners, LocalDateTime.now(clock)));
         return battleMapper.toResponse(battle);
     }
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -1,5 +1,11 @@
 package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
@@ -12,6 +18,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.member.entity.Member;
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -31,11 +38,6 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Import({WebSocketTestConfiguration.class, TestTimeConfig.class})
 @DisplayName("BattleWebSocketAcceptance")
@@ -106,7 +108,9 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
         박현준_Session = 웹소켓_연결(박현준_accessToken);
         노준혁_Session = 웹소켓_연결(노준혁_accessToken);
 
-        배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준, 노준혁), LocalDateTime.now(clock)));
+        배틀 =
+                battleRepository.save(
+                        new Battle(1000, List.of(박성우, 박현준, 노준혁), LocalDateTime.now(clock)));
 
         박성우_Queue = new LinkedBlockingDeque<>();
         박현준_Queue = new LinkedBlockingDeque<>();

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -1,11 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
@@ -18,7 +12,6 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.member.entity.Member;
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -38,6 +31,11 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Import({WebSocketTestConfiguration.class, TestTimeConfig.class})
 @DisplayName("BattleWebSocketAcceptance")
@@ -108,7 +106,7 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
         박현준_Session = 웹소켓_연결(박현준_accessToken);
         노준혁_Session = 웹소켓_연결(노준혁_accessToken);
 
-        배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준, 노준혁)));
+        배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준, 노준혁), LocalDateTime.now(clock)));
 
         박성우_Queue = new LinkedBlockingDeque<>();
         박현준_Queue = new LinkedBlockingDeque<>();

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,27 +1,17 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidNumberOfBattleRunnerException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.ReadyRunnerNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
 import online.partyrun.testmanager.docs.RestControllerTest;
-
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
@@ -29,8 +19,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @WebMvcTest(BattleController.class)
-@Import(TestTimeConfig.class)
 @DisplayName("BattleController")
 class BattleControllerTest extends RestControllerTest {
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,11 +1,19 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidNumberOfBattleRunnerException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.ReadyRunnerNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
 import online.partyrun.testmanager.docs.RestControllerTest;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -18,13 +26,6 @@ import org.springframework.test.web.servlet.ResultActions;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BattleController.class)
 @DisplayName("BattleController")

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
@@ -1,18 +1,12 @@
 package online.partyrun.partyrunbattleservice.domain.battle.entity;
 
-import static org.assertj.core.api.Assertions.*;
-
-import online.partyrun.partyrunbattleservice.domain.battle.exception.AllRunnersAreNotRunningStatusException;
-import online.partyrun.partyrunbattleservice.domain.battle.exception.BattleNotStartedException;
-import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidDistanceException;
-import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidRunnerNumberInBattleException;
+import online.partyrun.partyrunbattleservice.domain.battle.exception.*;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataTimeException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerNotFoundException;
-
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -21,6 +15,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.*;
+
 @DisplayName("Battle")
 class BattleTest {
 
@@ -28,6 +24,7 @@ class BattleTest {
     Runner 노준혁;
     Runner 박현준;
     Battle 배틀;
+    LocalDateTime now = LocalDateTime.now();
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -50,7 +47,7 @@ class BattleTest {
             @Test
             @DisplayName("배틀을 생성한다.")
             void createBattle() {
-                assertThatCode(() -> new Battle(distance, runnerList)).doesNotThrowAnyException();
+                assertThatCode(() -> new Battle(distance, runnerList, now)).doesNotThrowAnyException();
             }
         }
 
@@ -62,7 +59,7 @@ class BattleTest {
             @ValueSource(ints = {-1, 0})
             @DisplayName("예외를 던진다.")
             void throwException(int distance) {
-                assertThatThrownBy(() -> new Battle(distance, runnerList))
+                assertThatThrownBy(() -> new Battle(distance, runnerList, now))
                         .isInstanceOf(InvalidDistanceException.class);
             }
         }
@@ -75,8 +72,20 @@ class BattleTest {
             @NullAndEmptySource
             @DisplayName("예외를 던진다.")
             void throwException(List<Runner> runners) {
-                assertThatThrownBy(() -> new Battle(distance, runners))
+                assertThatThrownBy(() -> new Battle(distance, runners, now))
                         .isInstanceOf(InvalidRunnerNumberInBattleException.class);
+            }
+        }
+
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 생성시간이_없다면 {
+
+            @Test
+            @DisplayName("예외를 던진다.")
+            void throwException() {
+                assertThatThrownBy(() -> new Battle(distance, runnerList, null))
+                        .isInstanceOf(InvalidBattleCreatedAtException.class);
             }
         }
     }
@@ -90,7 +99,7 @@ class BattleTest {
             박성우 = new Runner("박성우");
             노준혁 = new Runner("노준혁");
             박현준 = new Runner("박현준");
-            배틀 = new Battle(1000, List.of(박성우, 박현준));
+            배틀 = new Battle(1000, List.of(박성우, 박현준), now);
         }
 
         @Test
@@ -120,7 +129,7 @@ class BattleTest {
         @BeforeEach
         void setUp() {
             박성우 = new Runner("박성우");
-            배틀 = new Battle(1000, List.of(박성우));
+            배틀 = new Battle(1000, List.of(박성우), now);
         }
 
         @Test
@@ -153,7 +162,7 @@ class BattleTest {
         @BeforeEach
         void setUp() {
             박성우 = new Runner("박성우");
-            배틀 = new Battle(1000, List.of(박성우));
+            배틀 = new Battle(1000, List.of(박성우), now);
         }
 
         @Test
@@ -198,7 +207,7 @@ class BattleTest {
         void setUp() {
             박성우 = new Runner("박성우");
             박현준 = new Runner("박현준");
-            배틀 = new Battle(1000, List.of(박성우, 박현준));
+            배틀 = new Battle(1000, List.of(박성우, 박현준), now);
         }
 
         @Nested
@@ -238,7 +247,7 @@ class BattleTest {
         @BeforeEach
         void setUp() {
             박성우 = new Runner("박성우");
-            배틀 = new Battle(1000, List.of(박성우));
+            배틀 = new Battle(1000, List.of(박성우), now);
 
             박성우.changeRunningStatus();
 
@@ -249,7 +258,7 @@ class BattleTest {
         @Test
         @DisplayName("배틀이 시작하지 않았으면 예외를 던진다.")
         void throwNotStartedException() {
-            Battle notStartedBattle = new Battle(1000, List.of(박성우));
+            Battle notStartedBattle = new Battle(1000, List.of(박성우), now);
             assertThatThrownBy(() -> notStartedBattle.addRecords(박성우.getId(), List.of()))
                     .isInstanceOf(BattleNotStartedException.class);
         }
@@ -293,7 +302,7 @@ class BattleTest {
         @BeforeEach
         void setUp() {
             박성우 = new Runner("박성우");
-            배틀 = new Battle(1000, List.of(박성우));
+            배틀 = new Battle(1000, List.of(박성우), now);
         }
 
         @Test
@@ -312,7 +321,7 @@ class BattleTest {
         @BeforeEach
         void setUp() {
             박성우 = new Runner("박성우");
-            배틀 = new Battle(1000, List.of(박성우));
+            배틀 = new Battle(1000, List.of(박성우), now);
 
             박성우.changeRunningStatus();
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
@@ -1,5 +1,7 @@
 package online.partyrun.partyrunbattleservice.domain.battle.entity;
 
+import static org.assertj.core.api.Assertions.*;
+
 import online.partyrun.partyrunbattleservice.domain.battle.exception.*;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
@@ -7,6 +9,7 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataTimeException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerNotFoundException;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -14,8 +17,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.*;
 
 @DisplayName("Battle")
 class BattleTest {
@@ -47,7 +48,8 @@ class BattleTest {
             @Test
             @DisplayName("배틀을 생성한다.")
             void createBattle() {
-                assertThatCode(() -> new Battle(distance, runnerList, now)).doesNotThrowAnyException();
+                assertThatCode(() -> new Battle(distance, runnerList, now))
+                        .doesNotThrowAnyException();
             }
         }
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDaoTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDaoTest.java
@@ -1,16 +1,17 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("BattleDao")
 @SpringBootTest
@@ -26,7 +27,9 @@ class BattleDaoTest {
         Runner 박성우 = new Runner("박성우");
         Runner 박현준 = new Runner("박현준");
         Runner 노준혁 = new Runner("노준혁");
-        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준, 노준혁), LocalDateTime.now()));
+        Battle 배틀 =
+                battleRepository.save(
+                        new Battle(1000, List.of(박성우, 박현준, 노준혁), LocalDateTime.now()));
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDaoTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDaoTest.java
@@ -1,16 +1,16 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDateTime;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("BattleDao")
 @SpringBootTest
@@ -26,7 +26,7 @@ class BattleDaoTest {
         Runner 박성우 = new Runner("박성우");
         Runner 박현준 = new Runner("박현준");
         Runner 노준혁 = new Runner("노준혁");
-        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준, 노준혁)));
+        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준, 노준혁), LocalDateTime.now()));
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,14 +1,10 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -17,6 +13,9 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataMongoTest
 @DisplayName("BattleRepository")
@@ -27,6 +26,7 @@ class BattleRepositoryTest {
     Runner 박성우 = new Runner("박성우");
     Runner 박현준 = new Runner("박현준");
     Runner 노준혁 = new Runner("노준혁");
+    LocalDateTime now = LocalDateTime.now();
 
     @AfterEach
     void tearDown() {
@@ -49,8 +49,8 @@ class BattleRepositoryTest {
         @Test
         @DisplayName("모든 러너가 현재 달리는 중이거나, 준비 상태라면 True를 반환한다.")
         void returnTrueAllRunner() {
-            final Battle 배틀1 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준)));
-            final Battle 배틀2 = battleRepository.save(new Battle(1000, List.of(노준혁)));
+            final Battle 배틀1 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준), now));
+            final Battle 배틀2 = battleRepository.save(new Battle(1000, List.of(노준혁), now));
 
             노준혁.changeRunningStatus();
             battleRepository.save(배틀2);
@@ -66,7 +66,7 @@ class BattleRepositoryTest {
         @Test
         @DisplayName("한명의 러너라도 현재 달리는 중이거나, 준비 상태라면 True를 반환한다.")
         void returnTrueOneRunner() {
-            final Battle 배틀2 = battleRepository.save(new Battle(1000, List.of(노준혁)));
+            final Battle 배틀2 = battleRepository.save(new Battle(1000, List.of(노준혁), now));
 
             boolean actual =
                     battleRepository.existsByRunnersIdInAndRunnersStatusIn(
@@ -80,7 +80,7 @@ class BattleRepositoryTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class findByRunnersIdAndRunnersStatus는 {
-        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준)));
+        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준), now));
 
         @Test
         @DisplayName("현재 준비 중인 배틀이 존재하면 반환한다.")
@@ -91,10 +91,10 @@ class BattleRepositoryTest {
                             .orElseThrow();
             final Battle 박현준_진행중_배틀 =
                     battleRepository
-                            .findByRunnersIdAndRunnersStatus(박성우.getId(), RunnerStatus.READY)
+                            .findByRunnersIdAndRunnersStatus(박현준.getId(), RunnerStatus.READY)
                             .orElseThrow();
 
-            assertThat(박성우_진행중_배틀).usingRecursiveComparison().isEqualTo(박현준_진행중_배틀).isEqualTo(배틀);
+            assertThat(박성우_진행중_배틀).usingRecursiveComparison().isEqualTo(박현준_진행중_배틀);
         }
 
         @Test
@@ -111,7 +111,7 @@ class BattleRepositoryTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class existsByIdAndRunnersIdAndRunnersStatus는 {
-        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준)));
+        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준), now));
 
         @Test
         @DisplayName("battleId, runnerId, status를 만족하는 데이터의 존재하면 true를 반환한다.")
@@ -140,7 +140,7 @@ class BattleRepositoryTest {
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 배틀_조회_시 {
 
-        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우)));
+        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우), now));
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -177,7 +177,7 @@ class BattleRepositoryTest {
         @BeforeEach
         void setUp() {
             int targetDistance = 100000;
-            배틀 = battleRepository.save(new Battle(targetDistance, List.of(박성우, 박현준)));
+            배틀 = battleRepository.save(new Battle(targetDistance, List.of(박성우, 박현준), now));
         }
 
         LocalDateTime now = LocalDateTime.now();

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,10 +1,14 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -13,9 +17,6 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataMongoTest
 @DisplayName("BattleRepository")

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,5 +1,15 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestApplicationContextConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
@@ -13,6 +23,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,15 +34,6 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 
 @SpringBootTest
 @Import({TestApplicationContextConfig.class, TestTimeConfig.class})

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,15 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestApplicationContextConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
@@ -23,7 +13,6 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -34,6 +23,15 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @SpringBootTest
 @Import({TestApplicationContextConfig.class, TestTimeConfig.class})
@@ -46,6 +44,12 @@ class BattleServiceTest {
     @Autowired MongoTemplate mongoTemplate;
     @Autowired ApplicationEventPublisher publisher;
     @Autowired Clock clock;
+    LocalDateTime now;
+
+    @BeforeEach
+    void setUpNow() {
+        now = LocalDateTime.now(clock);
+    }
 
     @AfterEach
     void setUp() {
@@ -151,9 +155,17 @@ class BattleServiceTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 러너의_상태를_RUNNING으로_변경할_때 {
-        Runner 박성우 = new Runner(memberRepository.save(멤버_박성우).getId());
-        Runner 노준혁 = new Runner(memberRepository.save(멤버_노준혁).getId());
-        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 노준혁)));
+
+        Runner 박성우;
+        Runner 노준혁;
+        Battle 배틀;
+
+        @BeforeEach
+        void setUp() {
+            박성우 = new Runner(memberRepository.save(멤버_박성우).getId());
+            노준혁 = new Runner(memberRepository.save(멤버_노준혁).getId());
+            배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 노준혁), now));
+        }
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -227,7 +239,7 @@ class BattleServiceTest {
         void setUp() {
             박성우 = new Runner(memberRepository.save(멤버_박성우).getId());
             노준혁 = new Runner(memberRepository.save(멤버_노준혁).getId());
-            Battle battle = new Battle(1000, List.of(박성우, 노준혁));
+            Battle battle = new Battle(1000, List.of(박성우, 노준혁), now);
             박성우.changeRunningStatus();
             노준혁.changeRunningStatus();
             배틀 = battleRepository.save(battle);
@@ -286,7 +298,7 @@ class BattleServiceTest {
 
         @BeforeEach
         void setUp() {
-            Battle 배틀 = new Battle(1000, List.of(박성우));
+            Battle 배틀 = new Battle(1000, List.of(박성우), now);
             배틀.changeRunnerRunningStatus(박성우.getId());
             배틀.setStartTime(now.minusMinutes(1));
 


### PR DESCRIPTION
## 변경 사항
Battle에서 생성 날짜를 저장하는 로직이 `@CreatedDate`로 설정되어있었습니다.
따라서 DB에 저장되는 시점에 DB 시간에 맞게 createdAt 필드가 설정되었습니다.
따라서 DB 서버 시간을 변경하려고 했지만, 실패했습니다.

MongoDB Atlas는 완전 관리형 데이터베이스이므로 서버 설정이 불가능한 것으로 판단합니다.

