### PR TITLE
배틀 결과를 조회한다.

### DIFF
--- a/src/docs/asciidoc/battle.adoc
+++ b/src/docs/asciidoc/battle.adoc
@@ -37,3 +37,7 @@ operation::get battle[snippets='http-request,http-response']
 
 operation::battle not found[snippets='http-request,http-response']
 
+=== 배틀 결과 조회
+러너가 배틀이 끝나고 결과를 조회할 때 (배틀을 끝낸 러너들만 조회 대상이 된다.)
+
+operation::get finished battle[snippets='http-request,http-response']

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/WebSocketConfig.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/WebSocketConfig.java
@@ -27,7 +27,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/battles/connection").setAllowedOrigins("*");
+        registry.addEndpoint("/ws/battles/connection").setAllowedOrigins("*");
     }
 
     @Override

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
@@ -38,7 +38,7 @@ public class BattleController {
 
     @GetMapping("{battleId}/finished")
     @ResponseStatus(HttpStatus.OK)
-    public FinishedBattleResponse getBattle(@PathVariable("battleId") String battleId, Authentication auth) {
+    public FinishedBattleResponse getFinishedBattle(@PathVariable("battleId") String battleId, Authentication auth) {
         return battleService.getFinishedBattle(battleId, auth.getName());
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
@@ -38,7 +38,8 @@ public class BattleController {
 
     @GetMapping("{battleId}/finished")
     @ResponseStatus(HttpStatus.OK)
-    public FinishedBattleResponse getFinishedBattle(@PathVariable("battleId") String battleId, Authentication auth) {
+    public FinishedBattleResponse getFinishedBattle(
+            @PathVariable("battleId") String battleId, Authentication auth) {
         return battleService.getFinishedBattle(battleId, auth.getName());
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
@@ -36,7 +36,7 @@ public class BattleController {
         return battleService.getReadyBattle(auth.getName());
     }
 
-    @GetMapping("{battleId}/finished")
+    @GetMapping("{battleId}")
     @ResponseStatus(HttpStatus.OK)
     public FinishedBattleResponse getFinishedBattle(
             @PathVariable("battleId") String battleId, Authentication auth) {

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
@@ -8,6 +8,7 @@ import lombok.experimental.FieldDefaults;
 
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
+import online.partyrun.partyrunbattleservice.domain.battle.dto.FinishedBattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
 
 import org.springframework.http.HttpStatus;
@@ -33,5 +34,11 @@ public class BattleController {
     @ResponseStatus(HttpStatus.OK)
     public BattleResponse getReadyBattle(Authentication auth) {
         return battleService.getReadyBattle(auth.getName());
+    }
+
+    @GetMapping("{battleId}/finished")
+    @ResponseStatus(HttpStatus.OK)
+    public FinishedBattleResponse getBattle(@PathVariable("battleId") String battleId, Authentication auth) {
+        return battleService.getFinishedBattle(battleId, auth.getName());
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/dto/FinishedBattleResponse.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/dto/FinishedBattleResponse.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunbattleservice.domain.battle.dto;
+
+import online.partyrun.partyrunbattleservice.domain.runner.dto.FinishedRunnerResponse;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record FinishedBattleResponse(double targetDistance, LocalDateTime startTime, List<FinishedRunnerResponse> runners) {
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/dto/FinishedBattleResponse.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/dto/FinishedBattleResponse.java
@@ -5,5 +5,5 @@ import online.partyrun.partyrunbattleservice.domain.runner.dto.FinishedRunnerRes
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record FinishedBattleResponse(double targetDistance, LocalDateTime startTime, List<FinishedRunnerResponse> runners) {
-}
+public record FinishedBattleResponse(
+        double targetDistance, LocalDateTime startTime, List<FinishedRunnerResponse> runners) {}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -3,6 +3,7 @@ package online.partyrun.partyrunbattleservice.domain.battle.service;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.event.BattleRunningEvent;
@@ -17,6 +18,7 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.service.RunnerService;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
@@ -132,14 +134,15 @@ public class BattleService {
         final Battle battle = findBattleExceptRunnerRecords(battleId, runnerId);
         final List<Runner> runners = battle.getRunners();
 
-        return new FinishedBattleResponse(battle.getTargetDistance(), battle.getStartTime(), toFinishedRunnerResponses(runners));
+        return new FinishedBattleResponse(
+                battle.getTargetDistance(),
+                battle.getStartTime(),
+                toFinishedRunnerResponses(runners));
     }
 
     private List<FinishedRunnerResponse> toFinishedRunnerResponses(List<Runner> runners) {
-        final List<Runner> finishedRunners = runners.stream()
-                .filter(Runner::isFinished)
-                .sorted()
-                .toList();
+        final List<Runner> finishedRunners =
+                runners.stream().filter(Runner::isFinished).sorted().toList();
 
         final List<FinishedRunnerResponse> result = new ArrayList<>();
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -3,7 +3,6 @@ package online.partyrun.partyrunbattleservice.domain.battle.service;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.event.BattleRunningEvent;
@@ -18,7 +17,6 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.service.RunnerService;
-
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
@@ -26,6 +24,8 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import static java.util.Comparator.comparing;
 
 @Service
 @RequiredArgsConstructor
@@ -142,7 +142,7 @@ public class BattleService {
 
     private List<FinishedRunnerResponse> toFinishedRunnerResponses(List<Runner> runners) {
         final List<Runner> finishedRunners =
-                runners.stream().filter(Runner::isFinished).sorted().toList();
+                runners.stream().filter(Runner::isFinished).sorted(comparing(Runner::getRecentRunnerRecord)).toList();
 
         final List<FinishedRunnerResponse> result = new ArrayList<>();
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -23,7 +23,6 @@ import org.springframework.stereotype.Service;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -137,18 +136,17 @@ public class BattleService {
     }
 
     private List<FinishedRunnerResponse> toFinishedRunnerResponses(List<Runner> runners) {
-        final List<Runner> copiedRunner = new ArrayList<>(runners);
-        Collections.sort(copiedRunner);
+        final List<Runner> finishedRunners = runners.stream()
+                .filter(Runner::isFinished)
+                .sorted()
+                .toList();
 
         final List<FinishedRunnerResponse> result = new ArrayList<>();
 
         int rank = 1;
-        for (Runner runner : copiedRunner) {
-            if (runner.isFinished()) {
-                FinishedRunnerResponse response = toFinishedRunnerResponse(runner, rank);
-                result.add(response);
-                rank++;
-            }
+        for (Runner runner : finishedRunners) {
+            FinishedRunnerResponse response = toFinishedRunnerResponse(runner, rank++);
+            result.add(response);
         }
 
         return result;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -127,4 +127,8 @@ public class BattleService {
     private List<GpsData> createGpsData(RunnerRecordRequest request) {
         return request.record().stream().map(GpsRequest::toEntity).toList();
     }
+
+    public FinishedBattleResponse getFinishedBattle(String battleId, String runnerId) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -1,8 +1,11 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
+import static java.util.Comparator.comparing;
+
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.event.BattleRunningEvent;
@@ -17,6 +20,7 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.service.RunnerService;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
@@ -24,8 +28,6 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-
-import static java.util.Comparator.comparing;
 
 @Service
 @RequiredArgsConstructor
@@ -142,7 +144,10 @@ public class BattleService {
 
     private List<FinishedRunnerResponse> toFinishedRunnerResponses(List<Runner> runners) {
         final List<Runner> finishedRunners =
-                runners.stream().filter(Runner::isFinished).sorted(comparing(Runner::getRecentRunnerRecord)).toList();
+                runners.stream()
+                        .filter(Runner::isFinished)
+                        .sorted(comparing(Runner::getRecentRunnerRecord))
+                        .toList();
 
         final List<FinishedRunnerResponse> result = new ArrayList<>();
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/dto/FinishedRunnerResponse.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/dto/FinishedRunnerResponse.java
@@ -1,0 +1,5 @@
+package online.partyrun.partyrunbattleservice.domain.runner.dto;
+
+import java.time.LocalDateTime;
+
+public record FinishedRunnerResponse(String id, int rank, LocalDateTime endTime) {}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/dto/RunnerResponse.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/dto/RunnerResponse.java
@@ -1,3 +1,0 @@
-package online.partyrun.partyrunbattleservice.domain.runner.dto;
-
-public record RunnerResponse(String id, String name) {}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
@@ -9,6 +9,7 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -17,7 +18,7 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @FieldDefaults(level = AccessLevel.PRIVATE)
-public class Runner {
+public class Runner implements Comparable<Runner> {
     private static final int DEFAULT_DISTANCE = 0;
     private static final int FIRST_GPSDATA = 0;
 
@@ -112,5 +113,21 @@ public class Runner {
         validateIsNotRunningStatus();
 
         this.status = RunnerStatus.FINISHED;
+    }
+
+    public LocalDateTime getEndTime() {
+        validateIsFinishedStatus();
+        return this.recentRunnerRecord.getTime();
+    }
+
+    private void validateIsFinishedStatus() {
+        if (!isFinished()) {
+            throw new RunnerIsNotFinisedException(this.id);
+        }
+    }
+
+    @Override
+    public int compareTo(Runner o) {
+        return this.recentRunnerRecord.compareTo(o.recentRunnerRecord);
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @FieldDefaults(level = AccessLevel.PRIVATE)
-public class Runner implements Comparable<Runner> {
+public class Runner {
     private static final int DEFAULT_DISTANCE = 0;
     private static final int FIRST_GPSDATA = 0;
 
@@ -124,10 +124,5 @@ public class Runner implements Comparable<Runner> {
         if (!isFinished()) {
             throw new RunnerIsNotFinisedException(this.id);
         }
-    }
-
-    @Override
-    public int compareTo(Runner o) {
-        return this.recentRunnerRecord.compareTo(o.recentRunnerRecord);
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/RunnerRecord.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/RunnerRecord.java
@@ -8,6 +8,7 @@ import lombok.experimental.FieldDefaults;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.IllegalRecordDistanceException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 
+import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Getter
@@ -51,5 +52,9 @@ public class RunnerRecord implements Comparable<RunnerRecord> {
     @Override
     public int compareTo(RunnerRecord o) {
         return this.gpsData.compareTo(o.gpsData);
+    }
+
+    public LocalDateTime getTime() {
+        return this.gpsData.getTime();
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/exception/RunnerIsNotFinisedException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/exception/RunnerIsNotFinisedException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunbattleservice.domain.runner.exception;
+
+import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
+
+public class RunnerIsNotFinisedException extends BadRequestException {
+    public RunnerIsNotFinisedException(String runnerId) {
+        super(String.format("%s의 러너는 현재 종료 상태가 아닙니다.", runnerId));
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -1,5 +1,11 @@
 package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
@@ -12,6 +18,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.member.entity.Member;
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -31,11 +38,6 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
-
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Import({WebSocketTestConfiguration.class, TestTimeConfig.class})
 @DisplayName("BattleWebSocketAcceptance")

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -1,11 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
@@ -18,7 +12,6 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.member.entity.Member;
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -38,6 +31,11 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
+
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Import({WebSocketTestConfiguration.class, TestTimeConfig.class})
 @DisplayName("BattleWebSocketAcceptance")
@@ -74,7 +72,7 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
 
             return webSocketStompClient
                     .connectAsync(
-                            "ws://localhost:" + port + "/api/battles/connection",
+                            "ws://localhost:" + port + "/api/ws/battles/connection",
                             headers,
                             new StompSessionHandlerAdapter() {})
                     .get(1, TimeUnit.SECONDS);

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,19 +1,13 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
+import online.partyrun.partyrunbattleservice.domain.battle.dto.FinishedBattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidNumberOfBattleRunnerException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.ReadyRunnerNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
+import online.partyrun.partyrunbattleservice.domain.runner.dto.FinishedRunnerResponse;
 import online.partyrun.testmanager.docs.RestControllerTest;
-
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -24,8 +18,16 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BattleController.class)
 @DisplayName("BattleController")
@@ -153,6 +155,35 @@ class BattleControllerTest extends RestControllerTest {
 
                 setPrintDocs(actions, "battle not found");
             }
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 배틀_결과를_조회할_때 {
+
+        @Test
+        @DisplayName("러너들의 결과를 반환한다.")
+        void getFinishedBattle() throws Exception {
+            String battleId = "battleId";
+            LocalDateTime now = LocalDateTime.now();
+            given(battleService.getFinishedBattle(battleId, "defaultUser"))
+                    .willReturn(new FinishedBattleResponse(1000, now.minusMinutes(5),
+                            List.of(new FinishedRunnerResponse("parkseongwoo", 1, now),new FinishedRunnerResponse("nojunhyuk", 2, now.plusMinutes(1))))
+                    );
+
+            final ResultActions actions =
+                    mockMvc.perform(
+                            get(String.format("%s/%s/finished", BATTLE_URL, battleId))
+                                    .header(
+                                            "Authorization",
+                                            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .characterEncoding(StandardCharsets.UTF_8));
+
+            actions.andExpect(status().isOk());
+
+            setPrintDocs(actions, "get finished battle");
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,5 +1,12 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.FinishedBattleResponse;
@@ -8,6 +15,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.exception.ReadyRunner
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
 import online.partyrun.partyrunbattleservice.domain.runner.dto.FinishedRunnerResponse;
 import online.partyrun.testmanager.docs.RestControllerTest;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -21,13 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BattleController.class)
 @DisplayName("BattleController")

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,5 +1,12 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.FinishedBattleResponse;
@@ -8,6 +15,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.exception.ReadyRunner
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
 import online.partyrun.partyrunbattleservice.domain.runner.dto.FinishedRunnerResponse;
 import online.partyrun.testmanager.docs.RestControllerTest;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -21,13 +29,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BattleController.class)
 @DisplayName("BattleController")
@@ -168,9 +169,14 @@ class BattleControllerTest extends RestControllerTest {
             String battleId = "battleId";
             LocalDateTime now = LocalDateTime.now();
             given(battleService.getFinishedBattle(battleId, "defaultUser"))
-                    .willReturn(new FinishedBattleResponse(1000, now.minusMinutes(5),
-                            List.of(new FinishedRunnerResponse("parkseongwoo", 1, now),new FinishedRunnerResponse("nojunhyuk", 2, now.plusMinutes(1))))
-                    );
+                    .willReturn(
+                            new FinishedBattleResponse(
+                                    1000,
+                                    now.minusMinutes(5),
+                                    List.of(
+                                            new FinishedRunnerResponse("parkseongwoo", 1, now),
+                                            new FinishedRunnerResponse(
+                                                    "nojunhyuk", 2, now.plusMinutes(1)))));
 
             final ResultActions actions =
                     mockMvc.perform(

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,12 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.FinishedBattleResponse;
@@ -15,7 +8,6 @@ import online.partyrun.partyrunbattleservice.domain.battle.exception.ReadyRunner
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
 import online.partyrun.partyrunbattleservice.domain.runner.dto.FinishedRunnerResponse;
 import online.partyrun.testmanager.docs.RestControllerTest;
-
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -29,6 +21,13 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BattleController.class)
 @DisplayName("BattleController")
@@ -180,7 +179,7 @@ class BattleControllerTest extends RestControllerTest {
 
             final ResultActions actions =
                     mockMvc.perform(
-                            get(String.format("%s/%s/finished", BATTLE_URL, battleId))
+                            get(String.format("%s/%s", BATTLE_URL, battleId))
                                     .header(
                                             "Authorization",
                                             "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,10 +1,14 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -13,9 +17,6 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataMongoTest
 @DisplayName("BattleRepository")

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,14 +1,10 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -17,6 +13,9 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataMongoTest
 @DisplayName("BattleRepository")
@@ -141,7 +140,7 @@ class BattleRepositoryTest {
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 배틀_조회_시 {
 
-        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우), now));
+        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 노준혁), now));
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -150,9 +149,12 @@ class BattleRepositoryTest {
             @BeforeEach
             void setUp() {
                 LocalDateTime now = LocalDateTime.now();
+                노준혁.changeRunningStatus();
                 박성우.changeRunningStatus();
                 배틀.setStartTime(now);
                 배틀.addRecords(박성우.getId(), List.of(GpsData.of(0, 0, 0, now.plusSeconds(10))));
+                배틀.addRecords(노준혁.getId(), List.of(GpsData.of(0, 0, 0, now.plusSeconds(10))));
+                battleRepository.save(배틀);
             }
 
             @Test

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -22,10 +22,8 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
-
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.testmanager.redis.EnableRedisTest;
-
 
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,5 +1,14 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestApplicationContextConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
@@ -14,6 +23,7 @@ import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepo
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,31 +35,17 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-
 @SpringBootTest
 @Import({TestApplicationContextConfig.class, TestTimeConfig.class})
 @DisplayName("BattleService")
 class BattleServiceTest {
 
-    @Autowired
-    BattleService battleService;
-    @Autowired
-    BattleRepository battleRepository;
-    @Autowired
-    MemberRepository memberRepository;
-    @Autowired
-    MongoTemplate mongoTemplate;
-    @Autowired
-    ApplicationEventPublisher publisher;
-    @Autowired
-    Clock clock;
+    @Autowired BattleService battleService;
+    @Autowired BattleRepository battleRepository;
+    @Autowired MemberRepository memberRepository;
+    @Autowired MongoTemplate mongoTemplate;
+    @Autowired ApplicationEventPublisher publisher;
+    @Autowired Clock clock;
     LocalDateTime now;
     Runner 박성우;
     Runner 노준혁;
@@ -85,7 +81,8 @@ class BattleServiceTest {
             @Test
             @DisplayName(" 생성된 배틀의 정보를 반환한다.")
             void returnBattle() {
-                BattleCreateRequest request = new BattleCreateRequest(1000, List.of(장세연.getId(), 이승열.getId()));
+                BattleCreateRequest request =
+                        new BattleCreateRequest(1000, List.of(장세연.getId(), 이승열.getId()));
 
                 final BattleResponse response = battleService.createBattle(request);
                 assertThat(response.id()).isNotNull();
@@ -99,7 +96,8 @@ class BattleServiceTest {
             @Test
             @DisplayName("예외를 던진다.")
             void throwExceptionsByAllRunner() {
-                BattleCreateRequest request = new BattleCreateRequest(1000, List.of(장세연.getId(), 이승열.getId()));
+                BattleCreateRequest request =
+                        new BattleCreateRequest(1000, List.of(장세연.getId(), 이승열.getId()));
 
                 battleService.createBattle(request);
 
@@ -116,14 +114,14 @@ class BattleServiceTest {
             @DisplayName("예외를 던진다.")
             void throwExceptionsByOneRunner() {
                 assertThatThrownBy(
-                        () ->
-                                battleService.createBattle(
-                                        new BattleCreateRequest(
-                                                1000,
-                                                List.of(
-                                                        박성우.getId(),
-                                                        장세연.getId(),
-                                                        이승열.getId()))))
+                                () ->
+                                        battleService.createBattle(
+                                                new BattleCreateRequest(
+                                                        1000,
+                                                        List.of(
+                                                                박성우.getId(),
+                                                                장세연.getId(),
+                                                                이승열.getId()))))
                         .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
             }
         }
@@ -172,12 +170,12 @@ class BattleServiceTest {
                 battleService.setRunnerRunning(배틀.getId(), 박성우.getId());
 
                 assertThat(
-                        battleRepository
-                                .findById(배틀.getId())
-                                .orElseThrow()
-                                .getRunners()
-                                .get(0)
-                                .getStatus())
+                                battleRepository
+                                        .findById(배틀.getId())
+                                        .orElseThrow()
+                                        .getRunners()
+                                        .get(0)
+                                        .getStatus())
                         .isEqualTo(RunnerStatus.RUNNING);
             }
         }
@@ -192,7 +190,7 @@ class BattleServiceTest {
             @DisplayName("예외를 던진다.")
             void throwException() {
                 assertThatThrownBy(
-                        () -> battleService.setRunnerRunning(invalidBattleId, 박성우.getId()))
+                                () -> battleService.setRunnerRunning(invalidBattleId, 박성우.getId()))
                         .isInstanceOf(BattleNotFoundException.class);
             }
         }
@@ -319,9 +317,9 @@ class BattleServiceTest {
         @DisplayName("배틀을 조회하지 못하면 예외를 던진다.")
         void throwException() {
             assertThatThrownBy(
-                    () ->
-                            battleService.calculateDistance(
-                                    "invalidBattleId", 박성우.getId(), RECORD_REQUEST1))
+                            () ->
+                                    battleService.calculateDistance(
+                                            "invalidBattleId", 박성우.getId(), RECORD_REQUEST1))
                     .isInstanceOf(BattleNotFoundException.class);
         }
 
@@ -361,8 +359,10 @@ class BattleServiceTest {
         @Test
         @DisplayName("종료되지 않은 러너의 결과는 반환하지 않는다.")
         void returnOnlyFinishedRunnerResult() {
-            FinishedBattleResponse response = battleService.getFinishedBattle(배틀.getId(), 박성우.getId());
-            assertThat(response.runners()).extracting("id", "rank")
+            FinishedBattleResponse response =
+                    battleService.getFinishedBattle(배틀.getId(), 박성우.getId());
+            assertThat(response.runners())
+                    .extracting("id", "rank")
                     .containsExactly(tuple(박성우.getId(), 1));
         }
 
@@ -372,8 +372,10 @@ class BattleServiceTest {
             배틀.addRecords(노준혁.getId(), List.of(gpsData0, gpsData2));
             mongoTemplate.save(배틀);
 
-            FinishedBattleResponse response = battleService.getFinishedBattle(배틀.getId(), 박성우.getId());
-            assertThat(response.runners()).extracting("id", "rank")
+            FinishedBattleResponse response =
+                    battleService.getFinishedBattle(배틀.getId(), 박성우.getId());
+            assertThat(response.runners())
+                    .extracting("id", "rank")
                     .containsExactly(tuple(박성우.getId(), 1), tuple(노준혁.getId(), 2));
         }
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,15 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestApplicationContextConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
@@ -23,7 +13,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
-
+import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,45 +25,68 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
 @SpringBootTest
 @Import({TestApplicationContextConfig.class, TestTimeConfig.class})
 @DisplayName("BattleService")
 class BattleServiceTest {
 
-    @Autowired BattleService battleService;
-    @Autowired BattleRepository battleRepository;
-    @Autowired MemberRepository memberRepository;
-    @Autowired MongoTemplate mongoTemplate;
-    @Autowired ApplicationEventPublisher publisher;
-    @Autowired Clock clock;
+    @Autowired
+    BattleService battleService;
+    @Autowired
+    BattleRepository battleRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    MongoTemplate mongoTemplate;
+    @Autowired
+    ApplicationEventPublisher publisher;
+    @Autowired
+    Clock clock;
     LocalDateTime now;
+    Runner 박성우;
+    Runner 노준혁;
+    Runner 박현준;
+    Runner 장세연;
+    Runner 이승열;
+    Battle 배틀;
 
     @BeforeEach
-    void setUpNow() {
+    void setUp() {
         now = LocalDateTime.now(clock);
+        박성우 = new Runner(memberRepository.save(멤버_박성우).getId());
+        노준혁 = new Runner(memberRepository.save(멤버_노준혁).getId());
+        박현준 = new Runner(memberRepository.save(멤버_박현준).getId());
+        장세연 = new Runner(memberRepository.save(멤버_장세연).getId());
+        이승열 = new Runner(memberRepository.save(멤버_이승열).getId());
+
+        배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 노준혁), now));
     }
 
     @AfterEach
-    void setUp() {
+    void tearDown() {
         mongoTemplate.getDb().drop();
     }
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 배틀을_생성할_때 {
-
-        Runner 박성우 = new Runner(memberRepository.save(멤버_박성우).getId());
-        Runner 노준혁 = new Runner(memberRepository.save(멤버_노준혁).getId());
-        Runner 박현준 = new Runner(memberRepository.save(멤버_박현준).getId());
-        BattleCreateRequest request =
-                new BattleCreateRequest(1000, List.of(박성우.getId(), 박현준.getId(), 노준혁.getId()));
-
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class 현재_배틀에_참여하고_있는_러너가_없다면 {
+
             @Test
             @DisplayName(" 생성된 배틀의 정보를 반환한다.")
             void returnBattle() {
+                BattleCreateRequest request = new BattleCreateRequest(1000, List.of(장세연.getId(), 이승열.getId()));
+
                 final BattleResponse response = battleService.createBattle(request);
                 assertThat(response.id()).isNotNull();
             }
@@ -86,6 +99,8 @@ class BattleServiceTest {
             @Test
             @DisplayName("예외를 던진다.")
             void throwExceptionsByAllRunner() {
+                BattleCreateRequest request = new BattleCreateRequest(1000, List.of(장세연.getId(), 이승열.getId()));
+
                 battleService.createBattle(request);
 
                 assertThatThrownBy(() -> battleService.createBattle(request))
@@ -96,24 +111,19 @@ class BattleServiceTest {
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class 한명이라도_다른_배틀에_참여하고_있는_러너가_있다면 {
-            Runner 장세연 = new Runner(memberRepository.save(멤버_장세연).getId());
-            Runner 이승열 = new Runner(memberRepository.save(멤버_이승열).getId());
 
             @Test
             @DisplayName("예외를 던진다.")
             void throwExceptionsByOneRunner() {
-
-                battleService.createBattle(request);
-
                 assertThatThrownBy(
-                                () ->
-                                        battleService.createBattle(
-                                                new BattleCreateRequest(
-                                                        1000,
-                                                        List.of(
-                                                                박성우.getId(),
-                                                                장세연.getId(),
-                                                                이승열.getId()))))
+                        () ->
+                                battleService.createBattle(
+                                        new BattleCreateRequest(
+                                                1000,
+                                                List.of(
+                                                        박성우.getId(),
+                                                        장세연.getId(),
+                                                        이승열.getId()))))
                         .isInstanceOf(RunnerAlreadyRunningInBattleException.class);
             }
         }
@@ -122,10 +132,6 @@ class BattleServiceTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 배틀을_조회할_때 {
-
-        Runner 박성우 = new Runner(memberRepository.save(멤버_박성우).getId());
-        BattleCreateRequest request = new BattleCreateRequest(1000, List.of(박성우.getId()));
-
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class runner의_id가_주어지면 {
@@ -133,9 +139,10 @@ class BattleServiceTest {
             @Test
             @DisplayName("진행중인 battle 정보 반환한다.")
             void returnBattleId() {
+                BattleCreateRequest request = new BattleCreateRequest(1000, List.of(장세연.getId()));
                 battleService.createBattle(request);
 
-                final BattleResponse response = battleService.getReadyBattle(박성우.getId());
+                final BattleResponse response = battleService.getReadyBattle(장세연.getId());
                 assertThat(response.id()).isNotNull();
             }
         }
@@ -143,12 +150,10 @@ class BattleServiceTest {
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class 현재_배틀에_참여하고있지_않는_runner의_id가_주어지면 {
-            Runner 노준혁 = new Runner(memberRepository.save(멤버_노준혁).getId());
-
             @Test
             @DisplayName("예외를 던진다.")
             void throwException() {
-                assertThatThrownBy(() -> battleService.getReadyBattle(노준혁.getId()))
+                assertThatThrownBy(() -> battleService.getReadyBattle(장세연.getId()))
                         .isInstanceOf(ReadyRunnerNotFoundException.class);
             }
         }
@@ -157,18 +162,6 @@ class BattleServiceTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 러너의_상태를_RUNNING으로_변경할_때 {
-
-        Runner 박성우;
-        Runner 노준혁;
-        Battle 배틀;
-
-        @BeforeEach
-        void setUp() {
-            박성우 = new Runner(memberRepository.save(멤버_박성우).getId());
-            노준혁 = new Runner(memberRepository.save(멤버_노준혁).getId());
-            배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 노준혁), now));
-        }
-
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class 배틀과_러너의_아이디를_받으면 {
@@ -179,12 +172,12 @@ class BattleServiceTest {
                 battleService.setRunnerRunning(배틀.getId(), 박성우.getId());
 
                 assertThat(
-                                battleRepository
-                                        .findById(배틀.getId())
-                                        .orElseThrow()
-                                        .getRunners()
-                                        .get(0)
-                                        .getStatus())
+                        battleRepository
+                                .findById(배틀.getId())
+                                .orElseThrow()
+                                .getRunners()
+                                .get(0)
+                                .getStatus())
                         .isEqualTo(RunnerStatus.RUNNING);
             }
         }
@@ -199,7 +192,7 @@ class BattleServiceTest {
             @DisplayName("예외를 던진다.")
             void throwException() {
                 assertThatThrownBy(
-                                () -> battleService.setRunnerRunning(invalidBattleId, 박성우.getId()))
+                        () -> battleService.setRunnerRunning(invalidBattleId, 박성우.getId()))
                         .isInstanceOf(BattleNotFoundException.class);
             }
         }
@@ -233,17 +226,11 @@ class BattleServiceTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 배틀을_시작할_때 {
-        Runner 박성우;
-        Runner 노준혁;
-        Battle 배틀;
-
         @BeforeEach
         void setUp() {
-            박성우 = new Runner(memberRepository.save(멤버_박성우).getId());
-            노준혁 = new Runner(memberRepository.save(멤버_노준혁).getId());
-            Battle battle = new Battle(1000, List.of(박성우, 노준혁), now);
             박성우.changeRunningStatus();
             노준혁.changeRunningStatus();
+            Battle battle = new Battle(1000, List.of(박성우, 노준혁), now);
             배틀 = battleRepository.save(battle);
         }
 
@@ -280,6 +267,8 @@ class BattleServiceTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 거리를_계산할_때 {
+
+        Battle 진행중인_배틀;
         LocalDateTime now = LocalDateTime.now().plusMinutes(1);
         GpsRequest GPS_REQUEST0 = new GpsRequest(0, 0, 0, now);
         GpsRequest GPS_REQUEST1 = new GpsRequest(0.001, 0.001, 0.001, now);
@@ -295,13 +284,11 @@ class BattleServiceTest {
         RunnerRecordRequest RECORD_REQUEST2 =
                 new RunnerRecordRequest(
                         List.of(GPS_REQUEST4, GPS_REQUEST5, GPS_REQUEST6, GPS_REQUEST7));
-        Runner 박성우 = new Runner("박성우");
-        Battle 진행중인_배틀;
 
         @BeforeEach
         void setUp() {
-            Battle 배틀 = new Battle(1000, List.of(박성우), now);
             배틀.changeRunnerRunningStatus(박성우.getId());
+            배틀.changeRunnerRunningStatus(노준혁.getId());
             배틀.setStartTime(now.minusMinutes(1));
 
             진행중인_배틀 = mongoTemplate.save(배틀);
@@ -332,9 +319,9 @@ class BattleServiceTest {
         @DisplayName("배틀을 조회하지 못하면 예외를 던진다.")
         void throwException() {
             assertThatThrownBy(
-                            () ->
-                                    battleService.calculateDistance(
-                                            "invalidBattleId", 박성우.getId(), RECORD_REQUEST1))
+                    () ->
+                            battleService.calculateDistance(
+                                    "invalidBattleId", 박성우.getId(), RECORD_REQUEST1))
                     .isInstanceOf(BattleNotFoundException.class);
         }
 
@@ -346,6 +333,48 @@ class BattleServiceTest {
             then(publisher)
                     .should(times(1))
                     .publishEvent(new RunnerFinishedEvent(진행중인_배틀.getId(), 박성우.getId()));
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 배틀_결과를_조회할_때 {
+        GpsData gpsData0;
+        GpsData gpsData1;
+        GpsData gpsData2;
+
+        @BeforeEach
+        void setUp() {
+            박성우.changeRunningStatus();
+            노준혁.changeRunningStatus();
+            배틀.setStartTime(now.minusMinutes(1));
+
+            gpsData0 = GpsData.of(0, 0, 0, now);
+            gpsData1 = GpsData.of(1, 1, 0, now.plusSeconds(1));
+            gpsData2 = GpsData.of(1, 1, 0, now.plusSeconds(2));
+
+            배틀.addRecords(박성우.getId(), List.of(gpsData0, gpsData1));
+
+            배틀 = mongoTemplate.save(배틀);
+        }
+
+        @Test
+        @DisplayName("종료되지 않은 러너의 결과는 반환하지 않는다.")
+        void returnOnlyFinishedRunnerResult() {
+            FinishedBattleResponse response = battleService.getFinishedBattle(배틀.getId(), 박성우.getId());
+            assertThat(response.runners()).extracting("id", "rank")
+                    .containsExactly(tuple(박성우.getId(), 1));
+        }
+
+        @Test
+        @DisplayName("종료된 러너들의 결과를 반환한다.")
+        void returnFinishedRunnerResult() {
+            배틀.addRecords(노준혁.getId(), List.of(gpsData0, gpsData2));
+            mongoTemplate.save(배틀);
+
+            FinishedBattleResponse response = battleService.getFinishedBattle(배틀.getId(), 박성우.getId());
+            assertThat(response.runners()).extracting("id", "rank")
+                    .containsExactly(tuple(박성우.getId(), 1), tuple(노준혁.getId(), 2));
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
@@ -1,21 +1,19 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidRecentRunnerRecordException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotFinisedException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotReadyException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotRunningException;
-
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Runner")
 class RunnerTest {
@@ -250,45 +248,6 @@ class RunnerTest {
             박성우.changeFinishStatus();
 
             assertThat(박성우.getEndTime()).isEqualTo(now.plusSeconds(1));
-        }
-    }
-
-    @Nested
-    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-    class 러너들_끼리_비교를_할_때 {
-
-        Runner 노준혁;
-
-        @BeforeEach
-        void setUp() {
-            LocalDateTime now = LocalDateTime.now();
-
-            박성우.changeRunningStatus();
-            GpsData GPSDATA_1 = GpsData.of(1, 1, 1, now);
-
-            박성우.addRecords(List.of(GPSDATA_1));
-
-            노준혁 = new Runner("노준혁");
-            노준혁.changeRunningStatus();
-            GpsData GPSDATA_2 = GpsData.of(2, 2, 2, now.plusSeconds(1));
-
-            노준혁.addRecords(List.of(GPSDATA_2));
-        }
-
-        @Test
-        @DisplayName("최근 기록이 더 이전일 수록 작다.")
-        void compareTo() {
-            assertThat(박성우.compareTo(노준혁)).isNegative();
-        }
-
-        @Test
-        @DisplayName("러너들을 정렬 할 때, 최근 기록 시간이 더 작을 수록 앞에 온다.")
-        void sort() {
-            final List<Runner> runners = new ArrayList<>(List.of(노준혁, 박성우));
-
-            Collections.sort(runners);
-
-            assertThat(runners).containsExactly(박성우, 노준혁);
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
@@ -1,19 +1,20 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidRecentRunnerRecordException;
+import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotFinisedException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotReadyException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotRunningException;
-
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Runner")
 class RunnerTest {
@@ -220,6 +221,73 @@ class RunnerTest {
             박성우.addRecords(recentGpsData);
 
             assertThat(박성우.getRecentDistance()).isPositive();
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 러너의_종료시간을_가져올_때 {
+
+        @Test
+        @DisplayName("러너가 종료상태가 아니라면 예외를 던진다.")
+        void throwException() {
+            assertThatThrownBy(() -> 박성우.getEndTime())
+                    .isInstanceOf(RunnerIsNotFinisedException.class);
+        }
+
+        @Test
+        @DisplayName("종료 시간을 반환한다.")
+        void returnEndTime() {
+            박성우.changeRunningStatus();
+            LocalDateTime now = LocalDateTime.now();
+            GpsData GPSDATA_1 = GpsData.of(1, 1, 1, now);
+            GpsData GPSDATA_2 = GpsData.of(2, 2, 2, now.plusSeconds(1));
+
+            List<GpsData> recentGpsData = List.of(GPSDATA_1, GPSDATA_2);
+
+            박성우.addRecords(recentGpsData);
+            박성우.changeFinishStatus();
+
+            assertThat(박성우.getEndTime()).isEqualTo(now.plusSeconds(1));
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 러너들_끼리_비교를_할_때 {
+
+        Runner 노준혁;
+
+        @BeforeEach
+        void setUp() {
+            LocalDateTime now = LocalDateTime.now();
+
+            박성우.changeRunningStatus();
+            GpsData GPSDATA_1 = GpsData.of(1, 1, 1, now);
+
+            박성우.addRecords(List.of(GPSDATA_1));
+
+            노준혁 = new Runner("노준혁");
+            노준혁.changeRunningStatus();
+            GpsData GPSDATA_2 = GpsData.of(2, 2, 2, now.plusSeconds(1));
+
+            노준혁.addRecords(List.of(GPSDATA_2));
+        }
+
+        @Test
+        @DisplayName("최근 기록이 더 이전일 수록 작다.")
+        void compareTo() {
+            assertThat(박성우.compareTo(노준혁)).isNegative();
+        }
+
+        @Test
+        @DisplayName("러너들을 정렬 할 때, 최근 기록 시간이 더 작을 수록 앞에 온다.")
+        void sort() {
+            final List<Runner> runners = new ArrayList<>(List.of(노준혁, 박성우));
+
+            Collections.sort(runners);
+
+            assertThat(runners).containsExactly(박성우, 노준혁);
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
@@ -1,19 +1,20 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidRecentRunnerRecordException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotFinisedException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotReadyException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotRunningException;
+
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Runner")
 class RunnerTest {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
@@ -1,20 +1,21 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidRecentRunnerRecordException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotFinisedException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotReadyException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotRunningException;
+
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Runner")
 class RunnerTest {


### PR DESCRIPTION
## 변경 사항
러너가 배틀을 종료하고, 배틀의 결과 페이지를 확인해야합니다.
이를 위한 데이터를 응답하는 API를 만들었습니다.

현재는 이 API에서 목표 거리, 시작 시간, 등수, 종료 시간을 응답합니다.

추후에 이 API에서 Gps 좌표들도 반환해야합니다.


## 알아야할 사항
1. 이 API 를 제대로 테스트하려면, 웹소켓 테스트와 인수 테스트를 합쳐야하는데, 시간이 없으므로 Controller 테스트까지만 진행했습니다.
2. 결과에는 종료된 상태의 러너에 대해서만 반환합니다. 달리고 있는 상태의 러너는 조회 대상에서 제외됩니다.

