### PR TITLE
러너가 배틀에 속해있다면 종료시킨다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
@@ -1,16 +1,11 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
 import jakarta.validation.Valid;
-
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
-import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
-import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
-import online.partyrun.partyrunbattleservice.domain.battle.dto.FinishedBattleResponse;
+import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
-
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
@@ -41,5 +36,11 @@ public class BattleController {
     public FinishedBattleResponse getFinishedBattle(
             @PathVariable("battleId") String battleId, Authentication auth) {
         return battleService.getFinishedBattle(battleId, auth.getName());
+    }
+
+    @PostMapping("/runners/finished")
+    @ResponseStatus(HttpStatus.OK)
+    public MessageResponse changeRunnerFinished(Authentication auth) {
+        return battleService.changeRunnerFinished(auth.getName());
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleController.java
@@ -1,11 +1,14 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
 import jakarta.validation.Valid;
+
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/dto/MessageResponse.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/dto/MessageResponse.java
@@ -1,4 +1,3 @@
 package online.partyrun.partyrunbattleservice.domain.battle.dto;
 
-public record MessageResponse(String message) {
-}
+public record MessageResponse(String message) {}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/dto/MessageResponse.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/dto/MessageResponse.java
@@ -1,0 +1,4 @@
+package online.partyrun.partyrunbattleservice.domain.battle.dto;
+
+public record MessageResponse(String message) {
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -15,6 +15,8 @@ public interface BattleRepository extends MongoRepository<Battle, String> {
     boolean existsByIdAndRunnersIdAndRunnersStatus(
             String battleId, String runnerId, RunnerStatus status);
 
+    boolean existsByRunnersAndRunnersStatusIn(String runnerId, List<RunnerStatus> ready);
+
     boolean existsByRunnersIdInAndRunnersStatusIn(List<String> runnersId, List<RunnerStatus> ready);
 
     Optional<Battle> findByRunnersIdAndRunnersStatus(String runnerId, RunnerStatus runnerStatus);
@@ -32,4 +34,8 @@ public interface BattleRepository extends MongoRepository<Battle, String> {
             List<RunnerRecord> runnerRecords,
             RunnerRecord recentRecord,
             RunnerStatus runnerStatus);
+
+    @Query(value = "{'runners.id': ?0, 'runners.status': { $in: ?1 }}")
+    @Update("{'$set' :  {'runners.$.status': ?3}}")
+    void updateReadyOrRunningRunnerStatus(String runnerId, List<RunnerStatus> preRunnerStatus, RunnerStatus runnerStatus);
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -37,5 +37,6 @@ public interface BattleRepository extends MongoRepository<Battle, String> {
 
     @Query(value = "{'runners.id': ?0, 'runners.status': { $in: ?1 }}")
     @Update("{'$set' :  {'runners.$.status': ?2}}")
-    void updateReadyOrRunningRunnerStatus(String runnerId, List<RunnerStatus> preRunnerStatus, RunnerStatus runnerStatus);
+    void updateReadyOrRunningRunnerStatus(
+            String runnerId, List<RunnerStatus> preRunnerStatus, RunnerStatus runnerStatus);
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -36,6 +36,6 @@ public interface BattleRepository extends MongoRepository<Battle, String> {
             RunnerStatus runnerStatus);
 
     @Query(value = "{'runners.id': ?0, 'runners.status': { $in: ?1 }}")
-    @Update("{'$set' :  {'runners.$.status': ?3}}")
+    @Update("{'$set' :  {'runners.$.status': ?2}}")
     void updateReadyOrRunningRunnerStatus(String runnerId, List<RunnerStatus> preRunnerStatus, RunnerStatus runnerStatus);
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -1,11 +1,8 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
-import static java.util.Comparator.comparing;
-
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
-
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.event.BattleRunningEvent;
@@ -21,7 +18,6 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.service.RunnerService;
 import online.partyrun.partyrunbattleservice.global.annotation.DistributedLock;
-
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
@@ -29,6 +25,8 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+
+import static java.util.Comparator.comparing;
 
 @Service
 @RequiredArgsConstructor
@@ -164,5 +162,11 @@ public class BattleService {
 
     private FinishedRunnerResponse toFinishedRunnerResponse(Runner runner, int rank) {
         return new FinishedRunnerResponse(runner.getId(), rank, runner.getEndTime());
+    }
+
+    public MessageResponse changeRunnerFinished(String runnerId) {
+        battleRepository.updateReadyOrRunningRunnerStatus(runnerId, List.of(RunnerStatus.READY, RunnerStatus.RUNNING), RunnerStatus.FINISHED);
+
+        return new MessageResponse("요청이 정상적으로 처리되었습니다.");
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -1,8 +1,11 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
+import static java.util.Comparator.comparing;
+
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.battle.event.BattleRunningEvent;
@@ -18,6 +21,7 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.service.RunnerService;
 import online.partyrun.partyrunbattleservice.global.annotation.DistributedLock;
+
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
@@ -25,8 +29,6 @@ import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-
-import static java.util.Comparator.comparing;
 
 @Service
 @RequiredArgsConstructor
@@ -165,7 +167,8 @@ public class BattleService {
     }
 
     public MessageResponse changeRunnerFinished(String runnerId) {
-        battleRepository.updateReadyOrRunningRunnerStatus(runnerId, List.of(RunnerStatus.READY, RunnerStatus.RUNNING), RunnerStatus.FINISHED);
+        battleRepository.updateReadyOrRunningRunnerStatus(
+                runnerId, List.of(RunnerStatus.READY, RunnerStatus.RUNNING), RunnerStatus.FINISHED);
 
         return new MessageResponse("요청이 정상적으로 처리되었습니다.");
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,5 +1,12 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.FinishedBattleResponse;
@@ -9,6 +16,7 @@ import online.partyrun.partyrunbattleservice.domain.battle.exception.ReadyRunner
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
 import online.partyrun.partyrunbattleservice.domain.runner.dto.FinishedRunnerResponse;
 import online.partyrun.testmanager.docs.RestControllerTest;
+
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -22,13 +30,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
-
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BattleController.class)
 @DisplayName("BattleController")
@@ -169,13 +170,14 @@ class BattleControllerTest extends RestControllerTest {
             String battleId = "battleId";
             LocalDateTime now = LocalDateTime.now();
 
-            FinishedBattleResponse response = new FinishedBattleResponse(
-                    1000,
-                    now.minusMinutes(5),
-                    List.of(
-                            new FinishedRunnerResponse("parkseongwoo", 1, now),
-                            new FinishedRunnerResponse(
-                                    "nojunhyuk", 2, now.plusMinutes(1))));
+            FinishedBattleResponse response =
+                    new FinishedBattleResponse(
+                            1000,
+                            now.minusMinutes(5),
+                            List.of(
+                                    new FinishedRunnerResponse("parkseongwoo", 1, now),
+                                    new FinishedRunnerResponse(
+                                            "nojunhyuk", 2, now.plusMinutes(1))));
 
             given(battleService.getFinishedBattle(battleId, "defaultUser")).willReturn(response);
 
@@ -188,8 +190,7 @@ class BattleControllerTest extends RestControllerTest {
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .characterEncoding(StandardCharsets.UTF_8));
 
-            actions.andExpect(status().isOk())
-                    .andExpect(content().json(toRequestBody(response)));
+            actions.andExpect(status().isOk()).andExpect(content().json(toRequestBody(response)));
 
             setPrintDocs(actions, "get finished battle");
         }
@@ -215,8 +216,7 @@ class BattleControllerTest extends RestControllerTest {
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .characterEncoding(StandardCharsets.UTF_8));
 
-            actions.andExpect(status().isOk())
-                    .andExpect(content().json(toRequestBody(response)));
+            actions.andExpect(status().isOk()).andExpect(content().json(toRequestBody(response)));
 
             setPrintDocs(actions, "get finished battle");
         }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,21 +1,14 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.FinishedBattleResponse;
+import online.partyrun.partyrunbattleservice.domain.battle.dto.MessageResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidNumberOfBattleRunnerException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.ReadyRunnerNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
 import online.partyrun.partyrunbattleservice.domain.runner.dto.FinishedRunnerResponse;
 import online.partyrun.testmanager.docs.RestControllerTest;
-
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -29,6 +22,13 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(BattleController.class)
 @DisplayName("BattleController")
@@ -168,15 +168,16 @@ class BattleControllerTest extends RestControllerTest {
         void getFinishedBattle() throws Exception {
             String battleId = "battleId";
             LocalDateTime now = LocalDateTime.now();
-            given(battleService.getFinishedBattle(battleId, "defaultUser"))
-                    .willReturn(
-                            new FinishedBattleResponse(
-                                    1000,
-                                    now.minusMinutes(5),
-                                    List.of(
-                                            new FinishedRunnerResponse("parkseongwoo", 1, now),
-                                            new FinishedRunnerResponse(
-                                                    "nojunhyuk", 2, now.plusMinutes(1)))));
+
+            FinishedBattleResponse response = new FinishedBattleResponse(
+                    1000,
+                    now.minusMinutes(5),
+                    List.of(
+                            new FinishedRunnerResponse("parkseongwoo", 1, now),
+                            new FinishedRunnerResponse(
+                                    "nojunhyuk", 2, now.plusMinutes(1))));
+
+            given(battleService.getFinishedBattle(battleId, "defaultUser")).willReturn(response);
 
             final ResultActions actions =
                     mockMvc.perform(
@@ -187,7 +188,35 @@ class BattleControllerTest extends RestControllerTest {
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .characterEncoding(StandardCharsets.UTF_8));
 
-            actions.andExpect(status().isOk());
+            actions.andExpect(status().isOk())
+                    .andExpect(content().json(toRequestBody(response)));
+
+            setPrintDocs(actions, "get finished battle");
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 러너가_접속했을_때 {
+
+        @Test
+        @DisplayName("배틀에 속해있다면 종료시킨다.")
+        void changeRunnerFinished() throws Exception {
+            MessageResponse response = new MessageResponse("요청이 정상적으로 처리되었습니다.");
+            given(battleService.changeRunnerFinished("defaultUser")).willReturn(response);
+
+            final ResultActions actions =
+                    mockMvc.perform(
+                            post(String.format("%s/runners/finished", BATTLE_URL))
+                                    .with(csrf())
+                                    .header(
+                                            "Authorization",
+                                            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .characterEncoding(StandardCharsets.UTF_8));
+
+            actions.andExpect(status().isOk())
+                    .andExpect(content().json(toRequestBody(response)));
 
             setPrintDocs(actions, "get finished battle");
         }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,10 +1,14 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -13,9 +17,6 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataMongoTest
 @DisplayName("BattleRepository")
@@ -240,16 +241,25 @@ class BattleRepositoryTest {
         @Test
         @DisplayName("Ready 또는 Running 상태의 러너를 Finished 상태로 변경한다.")
         void changeStatus() {
-            battleRepository.updateReadyOrRunningRunnerStatus(박성우.getId(), List.of(RunnerStatus.READY, RunnerStatus.RUNNING), RunnerStatus.FINISHED);
-            battleRepository.updateReadyOrRunningRunnerStatus(노준혁.getId(), List.of(RunnerStatus.READY, RunnerStatus.RUNNING), RunnerStatus.FINISHED);
+            battleRepository.updateReadyOrRunningRunnerStatus(
+                    박성우.getId(),
+                    List.of(RunnerStatus.READY, RunnerStatus.RUNNING),
+                    RunnerStatus.FINISHED);
+            battleRepository.updateReadyOrRunningRunnerStatus(
+                    노준혁.getId(),
+                    List.of(RunnerStatus.READY, RunnerStatus.RUNNING),
+                    RunnerStatus.FINISHED);
 
             Battle result1 = battleRepository.findById(배틀1.getId()).orElseThrow();
             Battle result2 = battleRepository.findById(배틀2.getId()).orElseThrow();
 
             assertAll(
-                    () -> assertThat(result1.getRunnerStatus(박성우.getId())).isEqualTo(RunnerStatus.FINISHED),
-                    () -> assertThat(result2.getRunnerStatus(노준혁.getId())).isEqualTo(RunnerStatus.FINISHED)
-            );
+                    () ->
+                            assertThat(result1.getRunnerStatus(박성우.getId()))
+                                    .isEqualTo(RunnerStatus.FINISHED),
+                    () ->
+                            assertThat(result2.getRunnerStatus(노준혁.getId()))
+                                    .isEqualTo(RunnerStatus.FINISHED));
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,14 +1,10 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -17,6 +13,9 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DataMongoTest
 @DisplayName("BattleRepository")
@@ -221,6 +220,36 @@ class BattleRepositoryTest {
                     () -> assertThat(battle.isRunnerFinished(박성우.getId())).isTrue(),
                     () -> assertThat(battle.getRunnerRecords(박현준.getId())).hasSize(2),
                     () -> assertThat(battle.isRunnerFinished(박현준.getId())).isFalse());
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class updateReadyOrRunningRunnerStatus는 {
+
+        Battle 배틀1;
+        Battle 배틀2;
+
+        @BeforeEach
+        void setUp() {
+            배틀1 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준), now));
+            노준혁.changeRunningStatus();
+            배틀2 = battleRepository.save(new Battle(1000, List.of(노준혁), now));
+        }
+
+        @Test
+        @DisplayName("Ready 또는 Running 상태의 러너를 Finished 상태로 변경한다.")
+        void changeStatus() {
+            battleRepository.updateReadyOrRunningRunnerStatus(박성우.getId(), List.of(RunnerStatus.READY, RunnerStatus.RUNNING), RunnerStatus.FINISHED);
+            battleRepository.updateReadyOrRunningRunnerStatus(노준혁.getId(), List.of(RunnerStatus.READY, RunnerStatus.RUNNING), RunnerStatus.FINISHED);
+
+            Battle result1 = battleRepository.findById(배틀1.getId()).orElseThrow();
+            Battle result2 = battleRepository.findById(배틀2.getId()).orElseThrow();
+
+            assertAll(
+                    () -> assertThat(result1.getRunnerStatus(박성우.getId())).isEqualTo(RunnerStatus.FINISHED),
+                    () -> assertThat(result2.getRunnerStatus(노준혁.getId())).isEqualTo(RunnerStatus.FINISHED)
+            );
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,14 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestApplicationContextConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
@@ -24,7 +15,6 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.testmanager.redis.EnableRedisTest;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,6 +25,14 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @SpringBootTest
 @EnableRedisTest
@@ -379,6 +377,17 @@ class BattleServiceTest {
             assertThat(response.runners())
                     .extracting("id", "rank")
                     .containsExactly(tuple(박성우.getId(), 1), tuple(노준혁.getId(), 2));
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 러너의_상태를_종료할_때 {
+
+        @Test
+        void changeRunnerFinished() {
+            MessageResponse response = battleService.changeRunnerFinished("박성우");
+            assertThat(response).isNotNull();
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,5 +1,14 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestApplicationContextConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
@@ -15,6 +24,7 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.testmanager.redis.EnableRedisTest;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -25,14 +35,6 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
-
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-import static org.assertj.core.api.Assertions.*;
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 
 @SpringBootTest
 @EnableRedisTest


### PR DESCRIPTION
## 변경 사항
앱을 실행했을 때, 매칭이나 다른 기능을 사용하려면 러너가 배틀에 속해있는지 확인해야합니다.
만약 속해있다면 종료시켜야합니다.

이를 위한 API 를 만들었습니다.


## 알아야할 사항
추후에는 앱 강제종료 시, 재연결을 하도록 기능을 변경할 예정입니다.

이 API도 변경되겠죠?
