### PR TITLE
멤버 생성 이벤트를 통해 멤버를 저장한다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,7 +156,8 @@ jacocoTestCoverageVerification {
                     '**.*Interceptor*',
                     '**.*Event*',
                     '**.*Advisor*',
-                    '**.*Parser*'
+                    '**.*Parser*',
+                    '**.*Listener*'
             ]
         }
 

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,8 @@ dependencies {
     implementation 'com.github.SWM-KAWAI-MANS:spring-security-authorization-manager:1.0.1'
     implementation 'org.springframework.boot:spring-boot-starter-aop'
     implementation 'org.redisson:redisson-spring-boot-starter:3.23.2'
+    implementation platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.0.1")
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs'
 
     //mapstruct
     implementation 'org.mapstruct:mapstruct:1.5.1.Final'

--- a/build.gradle
+++ b/build.gradle
@@ -157,7 +157,8 @@ jacocoTestCoverageVerification {
                     '**.*Event*',
                     '**.*Advisor*',
                     '**.*Parser*',
-                    '**.*Listener*'
+                    '**.*Listener*',
+                    '**.*Message*'
             ]
         }
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/SqsMessage.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/SqsMessage.java
@@ -1,0 +1,8 @@
+package online.partyrun.partyrunbattleservice.domain.battle.event;
+
+public record SqsMessage(String type, Object value) {
+    private static final String CREATED_EVENT_TYPE = "CREATED";
+    public boolean isCreatedMessage() {
+        return CREATED_EVENT_TYPE.equals(type);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/SqsMessage.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/SqsMessage.java
@@ -2,6 +2,7 @@ package online.partyrun.partyrunbattleservice.domain.battle.event;
 
 public record SqsMessage(String type, Object value) {
     private static final String CREATED_EVENT_TYPE = "CREATED";
+
     public boolean isCreatedMessage() {
         return CREATED_EVENT_TYPE.equals(type);
     }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/SqsMessageListener.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/SqsMessageListener.java
@@ -3,11 +3,15 @@ package online.partyrun.partyrunbattleservice.domain.battle.event;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.awspring.cloud.sqs.annotation.SqsListener;
+
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
+
 import online.partyrun.partyrunbattleservice.domain.member.service.MemberService;
+
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/SqsMessageListener.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/SqsMessageListener.java
@@ -1,0 +1,32 @@
+package online.partyrun.partyrunbattleservice.domain.battle.event;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.awspring.cloud.sqs.annotation.SqsListener;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunbattleservice.domain.member.service.MemberService;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class SqsMessageListener {
+
+    ObjectMapper objectMapper;
+    MemberService memberService;
+
+    @SqsListener(value = "${spring.cloud.aws.sqs.queue-url}")
+    public void receive(String message) throws JsonProcessingException {
+
+        JsonNode jsonNode = objectMapper.readTree(message);
+        final String event = jsonNode.get("Message").asText();
+        final SqsMessage sqsMessage = objectMapper.readValue(event, SqsMessage.class);
+
+        if (sqsMessage.isCreatedMessage()) {
+            memberService.save((String) sqsMessage.value());
+        }
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/member/service/MemberService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/member/service/MemberService.java
@@ -28,4 +28,9 @@ public class MemberService {
             throw new InvalidMemberException(memberIds);
         }
     }
+
+    public void save(String memberId) {
+        final Member member = new Member(memberId);
+        memberRepository.save(member);
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,6 +6,8 @@ auth:
   filter:
     exclusions: "/docs/index.html"
 
+---
+
 spring:
   profiles:
     active: test
@@ -13,6 +15,17 @@ spring:
   data:
     redis:
       url: redis://localhost:16379
+
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+      credentials:
+        access-key: TEST AWS SQS ACCESS KEY
+        secret-key: AWS SQS SECRET KEY
+
+      sqs:
+        queue-url: TEST QUEUE
 
 logging:
   level:
@@ -40,10 +53,18 @@ spring:
     redis:
       url: ${REDIS_URL}
 
+  cloud:
+    aws:
+      region:
+        static: ${AWS_SQS_REGION}
+      credentials:
+        access-key: ${AWS_SQS_ACCESS_KEY}
+        secret-key: ${AWS_SQS_SECRET_KEY}
+      sqs:
+        queue-url: ${AWS_SQS_QUEUE_URL}
+
 jwt:
   access-secret-key: ${JWT_ACCESS_SECRET_KEY}
   access-expire-second: ${JWT_ACCESS_EXPIRE_LENGTH}
   refresh-secret-key: ${JWT_REFRESH_SECRET_KEY}
   refresh-expire-second: ${JWT_REFRESH_EXPIRE_LENGTH}
-
-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,11 +21,11 @@ spring:
       region:
         static: ap-northeast-2
       credentials:
-        access-key: TEST AWS SQS ACCESS KEY
-        secret-key: AWS SQS SECRET KEY
+        access-key: TESTAWSSQSACCES
+        secret-key: AWSSQSSECRETKEY
 
       sqs:
-        queue-url: TEST QUEUE
+        queue-url: https://sqs.ap-northeast-2.amazonaws.com/111111111111/testqueue-dev
 
 logging:
   level:

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/member/service/MemberServiceTest.java
@@ -1,20 +1,18 @@
 package online.partyrun.partyrunbattleservice.domain.member.service;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.멤버_박성우;
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.멤버_박현준;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import online.partyrun.partyrunbattleservice.domain.member.entity.Member;
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.testmanager.redis.EnableRedisTest;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
+
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.멤버_박성우;
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.멤버_박현준;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @EnableRedisTest
@@ -56,6 +54,20 @@ class MemberServiceTest {
                 assertThatThrownBy(() -> memberService.findMembers(invalidIds))
                         .isInstanceOf(InvalidMemberException.class);
             }
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 멤버를_저장할_때 {
+
+        @Test
+        @DisplayName("멤버의 아이디를 통해 멤버를 저장한다.")
+        void save() {
+            final String memberId = "박성우";
+            memberService.save(memberId);
+
+            assertThat(memberRepository.findById(memberId)).isNotEmpty();
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/member/service/MemberServiceTest.java
@@ -1,18 +1,20 @@
 package online.partyrun.partyrunbattleservice.domain.member.service;
 
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.멤버_박성우;
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.멤버_박현준;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import online.partyrun.partyrunbattleservice.domain.member.entity.Member;
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.testmanager.redis.EnableRedisTest;
+
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
-
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.멤버_박성우;
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.멤버_박현준;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @EnableRedisTest


### PR DESCRIPTION
## 변경 사항

멤버 서비스에서 멤버가 생성되면, 멤버에서 생성되었다는 이벤트를 전송합니다. 
[멤버 생성 시 이벤트 전송 PR](https://github.com/SWM-KAWAI-MANS/party-run-authentication-service/pull/23)

Sqs로부터 이 이벤트를 받아서 멤버를 생성합니다.

배틀에서 멤버가 존재해야 러너를 생성할 수 있습니다.


## 알아야할 사항
```java
    @SqsListener(value = "${spring.cloud.aws.sqs.queue-url}")
    public void receive(String message) throws JsonProcessingException {

        JsonNode jsonNode = objectMapper.readTree(message);
        final String event = jsonNode.get("Message").asText();
        final SqsMessage sqsMessage = objectMapper.readValue(event, SqsMessage.class);

        if (sqsMessage.isCreatedMessage()) {
            memberService.save((String) sqsMessage.value());
        }
    }
```
SqsMessageListner의 메소드에서 파라미터로 객체를 넣을 수 있는 것 같습니다. 객체를 넣는다면 objectMapper를 사용할 필요가 없습니다.
그런데 제가 하니까 안되더라구요.

그래서 빠르게 구현하기 위해서 objectMapper를 사용했습니다.
추후에 변경이 되어야합니다.

그리고 테스트를 실행해보면 sqs 로부터 계속해서 polling을 실행합니다. 따라서 에러가 납니다. 테스트 환경에서는 mock sqs url을 넣었거든요.
테스트가 실패하지는 않지만, polling에 실패했다는 예외가 계속 발생합니다.
이 또한 시간 이슈로 해결하지 못하고 pr 날립니다. 추후에 해결해야겠지요
