### PR TITLE
멤버를 제거한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/SqsMessage.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/SqsMessage.java
@@ -2,8 +2,13 @@ package online.partyrun.partyrunbattleservice.domain.battle.event;
 
 public record SqsMessage(String type, Object value) {
     private static final String CREATED_EVENT_TYPE = "CREATED";
+    private static final String DELETED_EVENT_TYPE = "DELETED";
 
     public boolean isCreatedMessage() {
         return CREATED_EVENT_TYPE.equals(type);
+    }
+
+    public boolean isDeletedMessage() {
+        return DELETED_EVENT_TYPE.equals(type);
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/SqsMessageListener.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/SqsMessageListener.java
@@ -32,5 +32,9 @@ public class SqsMessageListener {
         if (sqsMessage.isCreatedMessage()) {
             memberService.save((String) sqsMessage.value());
         }
+
+        if (sqsMessage.isDeletedMessage()) {
+            memberService.delete((String) sqsMessage.value());
+        }
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/member/exception/MemberNotFoundException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/member/exception/MemberNotFoundException.java
@@ -1,0 +1,9 @@
+package online.partyrun.partyrunbattleservice.domain.member.exception;
+
+import online.partyrun.partyrunbattleservice.global.exception.NotFoundException;
+
+public class MemberNotFoundException extends NotFoundException {
+    public MemberNotFoundException(String memberId) {
+        super(String.format("%s 아이디의 멤버를 찾을 수 없습니다.", memberId));
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/member/service/MemberService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/member/service/MemberService.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.experimental.FieldDefaults;
 
 import online.partyrun.partyrunbattleservice.domain.member.entity.Member;
+import online.partyrun.partyrunbattleservice.domain.member.exception.MemberNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 
+import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -32,5 +34,10 @@ public class MemberService {
     public void save(String memberId) {
         final Member member = new Member(memberId);
         memberRepository.save(member);
+    }
+
+    public void delete(String memberId) {
+        final Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
+        memberRepository.delete(member);
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/member/service/MemberService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/member/service/MemberService.java
@@ -8,7 +8,6 @@ import online.partyrun.partyrunbattleservice.domain.member.entity.Member;
 import online.partyrun.partyrunbattleservice.domain.member.exception.MemberNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 
-import org.springframework.boot.actuate.autoconfigure.endpoint.web.CorsEndpointProperties;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -37,7 +36,10 @@ public class MemberService {
     }
 
     public void delete(String memberId) {
-        final Member member = memberRepository.findById(memberId).orElseThrow(() -> new MemberNotFoundException(memberId));
+        final Member member =
+                memberRepository
+                        .findById(memberId)
+                        .orElseThrow(() -> new MemberNotFoundException(memberId));
         memberRepository.delete(member);
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/member/service/MemberServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/member/service/MemberServiceTest.java
@@ -7,9 +7,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import online.partyrun.partyrunbattleservice.domain.member.entity.Member;
+import online.partyrun.partyrunbattleservice.domain.member.exception.MemberNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.testmanager.redis.EnableRedisTest;
 
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -70,6 +72,30 @@ class MemberServiceTest {
             memberService.save(memberId);
 
             assertThat(memberRepository.findById(memberId)).isNotEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 멤버를_삭제할_때 {
+
+        @Test
+        @DisplayName("멤버의 아이디를 통해 멤버를 삭제한다.")
+        void save() {
+            final String memberId = "박성우";
+            memberService.save(memberId);
+            Assertions.assertThat(memberRepository.findById(memberId)).isPresent();
+
+            memberService.delete(memberId);
+            assertThat(memberRepository.findById(memberId)).isEmpty();
+        }
+
+        @Test
+        @DisplayName("멤버가 존재하지않으면 예외를 던진다.")
+        void throwException() {
+            final String memberId = "박성우";
+            Assertions.assertThatThrownBy(() -> memberService.delete(memberId))
+                    .isInstanceOf(MemberNotFoundException.class);
         }
     }
 }


### PR DESCRIPTION
## 변경 사항
멤버 서비스에서 멤버가 제거되면 배틀에서도 멤버를 제거하도록 구현하였습니다.
멤버 서비스에서는 soft delete를 합니다.
하지만 배틀 서비스에서는 hard delete를 합니다. 
배틀 서비스에서는 멤버 정보에 대해서 가지고 있지 않기 때문입니다.
굳이 정보도 없는데 갖고 있을 필요가 없습니다.

