### PR TITLE
결과 조회 시, 각 러너의 GPS 기록을 조회한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/dto/BattleResponse.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/dto/BattleResponse.java
@@ -1,9 +1,29 @@
 package online.partyrun.partyrunbattleservice.domain.battle.dto;
 
+import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.dto.RunnerResponse;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
-public record BattleResponse(
-        double targetDistance, LocalDateTime startTime, List<RunnerResponse> runners) {}
+public record BattleResponse(double targetDistance, LocalDateTime startTime, List<RunnerResponse> runners) {
+
+    public static BattleResponse from(Battle battle) {
+        final List<Runner> runnersOrderByRank = battle.getRunnersOrderByRank();
+        return new BattleResponse(battle.getTargetDistance(), battle.getStartTime(), toRunnerResponses(runnersOrderByRank));
+    }
+
+    private static List<RunnerResponse> toRunnerResponses(List<Runner> runners) {
+        final List<RunnerResponse> result = new ArrayList<>();
+
+        int rank = 1;
+        for (Runner runner : runners) {
+            RunnerResponse response = new RunnerResponse(rank++, runner);
+            result.add(response);
+        }
+
+        return result;
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -39,4 +39,6 @@ public interface BattleRepository extends MongoRepository<Battle, String> {
     @Update("{'$set' :  {'runners.$.status': ?2}}")
     void updateReadyOrRunningRunnerStatus(
             String runnerId, List<RunnerStatus> preRunnerStatus, RunnerStatus runnerStatus);
+
+    Optional<Battle> findByIdAndRunnersId(String battleId, String runnerId);
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/dto/RunnerRecordResponse.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/dto/RunnerRecordResponse.java
@@ -1,0 +1,17 @@
+package online.partyrun.partyrunbattleservice.domain.runner.dto;
+
+import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
+
+import java.time.LocalDateTime;
+
+public record RunnerRecordResponse(double longitude, double latitude, double altitude, LocalDateTime time, double distance) {
+
+    public RunnerRecordResponse(RunnerRecord runnerRecord) {
+        this(runnerRecord.getGpsData().getLocation().getPoint().getX(),
+                runnerRecord.getGpsData().getLocation().getPoint().getY(),
+                runnerRecord.getGpsData().getLocation().getAltitude(),
+                runnerRecord.getGpsData().getTime(),
+                runnerRecord.getDistance()
+        );
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/dto/RunnerResponse.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/dto/RunnerResponse.java
@@ -1,5 +1,13 @@
 package online.partyrun.partyrunbattleservice.domain.runner.dto;
 
-import java.time.LocalDateTime;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 
-public record RunnerResponse(String id, int rank, LocalDateTime endTime) {}
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record RunnerResponse(String id, int rank, LocalDateTime endTime, List<RunnerRecordResponse> records) {
+
+    public RunnerResponse(int rank, Runner runner) {
+        this(runner.getId(), rank, runner.getLastRecordTime(), runner.getRunnerRecords().stream().map(RunnerRecordResponse::new).toList());
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/HaversineDistanceCalculator.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/HaversineDistanceCalculator.java
@@ -10,9 +10,9 @@ public class HaversineDistanceCalculator implements DistanceCalculator<GeoJsonPo
         final double lat1 = point1.getY();
         final double lng1 = point1.getX();
         final double lat2 = point2.getY();
-        final double lhg2 = point2.getX();
+        final double lng2 = point2.getX();
 
-        return EARTH_RADIUS * distanceRadians(lat1, lng1, lat2, lhg2);
+        return EARTH_RADIUS * distanceRadians(lat1, lng1, lat2, lng2);
     }
 
     private double distanceRadians(double lat1, double lng1, double lat2, double lng2) {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -179,11 +179,11 @@ class BattleControllerTest extends RestControllerTest {
                                             new RunnerRecordResponse(0.00001, 0.00001, 0, now, 1.5)
                                     )
                             ),
-                            new RunnerResponse("runner노준혁", 1, now,
+                            new RunnerResponse("runner노준혁", 2, now,
                                     List.of(
                                             new RunnerRecordResponse(0, 0, 0, now.minusSeconds(1), 0),
                                             new RunnerRecordResponse(0.000005, 0.000005, 0, now, 0.75),
-                                            new RunnerRecordResponse(0.00001, 0.00001, 0, now.plusSeconds(1), 0.75)
+                                            new RunnerRecordResponse(0.00001, 0.00001, 0, now.plusSeconds(1), 1.5)
                                     )
                             )
                     )

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleControllerTest.java
@@ -1,12 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
-import static org.mockito.BDDMockito.given;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleCreateRequest;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleIdResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.BattleResponse;
@@ -14,9 +7,9 @@ import online.partyrun.partyrunbattleservice.domain.battle.dto.MessageResponse;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.InvalidNumberOfBattleRunnerException;
 import online.partyrun.partyrunbattleservice.domain.battle.exception.ReadyRunnerNotFoundException;
 import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
+import online.partyrun.partyrunbattleservice.domain.runner.dto.RunnerRecordResponse;
 import online.partyrun.partyrunbattleservice.domain.runner.dto.RunnerResponse;
 import online.partyrun.testmanager.docs.RestControllerTest;
-
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -31,13 +24,21 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 @WebMvcTest(BattleController.class)
 @DisplayName("BattleController")
 class BattleControllerTest extends RestControllerTest {
 
     private static final String BATTLE_URL = "/battles";
 
-    @MockBean BattleService battleService;
+    @MockBean
+    BattleService battleService;
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -170,13 +171,23 @@ class BattleControllerTest extends RestControllerTest {
             String battleId = "battleId";
             LocalDateTime now = LocalDateTime.now();
 
-            BattleResponse response =
-                    new BattleResponse(
-                            1000,
-                            now.minusMinutes(5),
-                            List.of(
-                                    new RunnerResponse("parkseongwoo", 1, now),
-                                    new RunnerResponse("nojunhyuk", 2, now.plusMinutes(1))));
+
+            BattleResponse response = new BattleResponse(1.5, now.minusMinutes(5),
+                    List.of(new RunnerResponse("runner박성우", 1, now,
+                                    List.of(
+                                            new RunnerRecordResponse(0, 0, 0, now.minusSeconds(1), 0),
+                                            new RunnerRecordResponse(0.00001, 0.00001, 0, now, 1.5)
+                                    )
+                            ),
+                            new RunnerResponse("runner노준혁", 1, now,
+                                    List.of(
+                                            new RunnerRecordResponse(0, 0, 0, now.minusSeconds(1), 0),
+                                            new RunnerRecordResponse(0.000005, 0.000005, 0, now, 0.75),
+                                            new RunnerRecordResponse(0.00001, 0.00001, 0, now.plusSeconds(1), 0.75)
+                                    )
+                            )
+                    )
+            );
 
             given(battleService.getBattle(battleId, "defaultUser")).willReturn(response);
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,14 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestApplicationContextConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
@@ -24,7 +15,6 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.testmanager.redis.EnableRedisTest;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,6 +25,14 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @SpringBootTest
 @EnableRedisTest
@@ -368,6 +366,13 @@ class BattleServiceTest {
             assertThat(response.runners())
                     .extracting("id", "rank")
                     .containsExactly(tuple(박성우.getId(), 1), tuple(노준혁.getId(), 2));
+        }
+
+        @Test
+        @DisplayName("러너가 배틀에 존재하지않았다면 예외를 던진다.")
+        void throwNotFoundException() {
+            assertThatThrownBy(() -> battleService.getBattle(배틀.getId(), 박현준.getId()))
+                    .isInstanceOf(BattleNotFoundException.class);
         }
     }
 


### PR DESCRIPTION
## 변경 사항
우리는 지도에 각 러너의 GPS 기록을 조회해야합니다.
하지만, 현재까지는 등수에 대한 정보만 주었습니다.

이 PR에서 결과 조회 시, GPS 기록도 전달하도록 구현하였습니다.
이를 통해 안드로이드에서 구글 지도 상에 GPS 기록을 띄울 수 있게 됩니다.

## 알아야할 사항
Response를 생성하는 로직을 Response 내부에서 처리하도록 변경하였습니다.

결과 조회 요청이 들어오면 아래와 같은 형식으로 응답이 전달됩니다.
![image](https://github.com/SWM-KAWAI-MANS/party-run-battle-service/assets/79205414/6b2f1451-b054-4d1a-bb82-1031cddb6d1e)

