### PR TITLE
배틀 진행 시, GPS 좌표에 속력 제한 기능을 추가한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
@@ -10,10 +10,7 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerR
 import online.partyrun.partyrunbattleservice.domain.runner.exception.*;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -61,7 +58,7 @@ public class Runner {
         final List<RunnerRecord> newRecords = createRecords(gpsData);
 
         this.runnerRecords.addAll(newRecords);
-        this.recentRunnerRecord = Collections.max(newRecords);
+        this.recentRunnerRecord = Collections.max(this.runnerRecords);
     }
 
     private void validateIsNotRunningStatus() {
@@ -77,6 +74,7 @@ public class Runner {
         if (hasNotRecentRecord()) {
             final GpsData firstGpsData = copiedGpsData.get(FIRST_GPSDATA_INDEX);
             final RunnerRecord firstRecord = new RunnerRecord(firstGpsData, DEFAULT_DISTANCE);
+            this.runnerRecords.add(firstRecord);
 
             return createRecords(firstRecord, copiedGpsData);
         }
@@ -86,9 +84,13 @@ public class Runner {
 
     private List<RunnerRecord> createRecords(RunnerRecord record, List<GpsData> gpsData) {
         List<RunnerRecord> records = new ArrayList<>();
+
         for (GpsData newGpsData : gpsData) {
-            record = record.createNextRecord(newGpsData);
-            records.add(record);
+            final Optional<RunnerRecord> newRecord = record.createNextRecord(newGpsData);
+            if (newRecord.isPresent()) {
+                record = newRecord.get();
+                records.add(record);
+            }
         }
 
         return records;

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
@@ -17,7 +17,7 @@ import java.util.*;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Runner {
     private static final int DEFAULT_DISTANCE = 0;
-    private static final int FIRST_GPSDATA_INDEX = 0;
+    private static final int FIRST_GPS_DATA_INDEX = 0;
 
     String id;
     RunnerStatus status = RunnerStatus.READY;
@@ -72,7 +72,7 @@ public class Runner {
         Collections.sort(copiedGpsData);
 
         if (hasNotRecentRecord()) {
-            final GpsData firstGpsData = copiedGpsData.get(FIRST_GPSDATA_INDEX);
+            final GpsData firstGpsData = copiedGpsData.get(FIRST_GPS_DATA_INDEX);
             final RunnerRecord firstRecord = new RunnerRecord(firstGpsData, DEFAULT_DISTANCE);
             this.runnerRecords.add(firstRecord);
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
@@ -20,7 +20,7 @@ import java.util.Objects;
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class Runner {
     private static final int DEFAULT_DISTANCE = 0;
-    private static final int FIRST_GPSDATA = 0;
+    private static final int FIRST_GPSDATA_INDEX = 0;
 
     String id;
     RunnerStatus status = RunnerStatus.READY;
@@ -75,7 +75,7 @@ public class Runner {
         Collections.sort(copiedGpsData);
 
         if (hasNotRecentRecord()) {
-            final GpsData firstGpsData = copiedGpsData.get(FIRST_GPSDATA);
+            final GpsData firstGpsData = copiedGpsData.get(FIRST_GPSDATA_INDEX);
             final RunnerRecord firstRecord = new RunnerRecord(firstGpsData, DEFAULT_DISTANCE);
 
             return createRecords(firstRecord, copiedGpsData);

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/GpsData.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/GpsData.java
@@ -10,6 +10,7 @@ import online.partyrun.partyrunbattleservice.domain.runner.exception.GpsTimeNull
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.PastGpsDataTimeException;
 
+import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.Objects;
 
@@ -18,6 +19,7 @@ import java.util.Objects;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @FieldDefaults(level = AccessLevel.PRIVATE)
 public class GpsData implements Comparable<GpsData> {
+    private static final double MAXIMUM_RUNNER_SPEED_OF_METERS_PER_SECOND = 12.42;
     Location location;
     LocalDateTime time;
 
@@ -41,6 +43,14 @@ public class GpsData implements Comparable<GpsData> {
         validateNull(other);
         validateIsBeforeData(other.time);
         return this.location.calculateDistance(other.location, new HaversineDistanceCalculator());
+    }
+
+    public double calculateDuration(GpsData other) {
+        validateNull(other);
+        validateIsBeforeData(other.time);
+
+        final double nanos = Duration.between(this.time, other.time).toNanos();
+        return nanos / 1_000_000_000;
     }
 
     private void validateNull(GpsData other) {

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/RunnerRecord.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/RunnerRecord.java
@@ -45,7 +45,7 @@ public class RunnerRecord implements Comparable<RunnerRecord> {
         final double movingDistance = this.gpsData.calculateDistance(gpsData);
         final double durationSeconds = this.gpsData.calculateDuration(gpsData);
 
-        if (movingDistance == MIN_DURATION_SECOND) {
+        if (durationSeconds == MIN_DURATION_SECOND) {
             return Optional.empty();
         }
 

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/RunnerRecord.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/RunnerRecord.java
@@ -42,16 +42,16 @@ public class RunnerRecord implements Comparable<RunnerRecord> {
     }
 
     public Optional<RunnerRecord> createNextRecord(GpsData gpsData) {
-        final double movingDistance = this.gpsData.calculateDistance(gpsData);
+        final double movingDistanceMeter = this.gpsData.calculateDistance(gpsData);
         final double durationSeconds = this.gpsData.calculateDuration(gpsData);
 
         if (durationSeconds == MIN_DURATION_SECOND) {
             return Optional.empty();
         }
 
-        final double runnerSpeedOfMetersPerSecond = movingDistance / durationSeconds;
+        final double runnerSpeedOfMetersPerSecond = movingDistanceMeter / durationSeconds;
         if (MAXIMUM_RUNNER_SPEED_OF_METERS_PER_SECOND >= runnerSpeedOfMetersPerSecond) {
-            return Optional.of(new RunnerRecord(gpsData, this.distance + movingDistance));
+            return Optional.of(new RunnerRecord(gpsData, this.distance + movingDistanceMeter));
         }
 
         return Optional.empty();

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/RunnerRecord.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/RunnerRecord.java
@@ -42,16 +42,16 @@ public class RunnerRecord implements Comparable<RunnerRecord> {
     }
 
     public Optional<RunnerRecord> createNextRecord(GpsData gpsData) {
-        final double distanceBetweenGpsData = this.gpsData.calculateDistance(gpsData);
+        final double movingDistance = this.gpsData.calculateDistance(gpsData);
         final double durationSeconds = this.gpsData.calculateDuration(gpsData);
 
-        if (distanceBetweenGpsData == MIN_DURATION_SECOND) {
+        if (movingDistance == MIN_DURATION_SECOND) {
             return Optional.empty();
         }
 
-        final double runnerSpeedOfMetersPerSecond = distanceBetweenGpsData / durationSeconds;
+        final double runnerSpeedOfMetersPerSecond = movingDistance / durationSeconds;
         if (MAXIMUM_RUNNER_SPEED_OF_METERS_PER_SECOND >= runnerSpeedOfMetersPerSecond) {
-            return Optional.of(new RunnerRecord(gpsData, this.distance + distanceBetweenGpsData));
+            return Optional.of(new RunnerRecord(gpsData, this.distance + movingDistance));
         }
 
         return Optional.empty();

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/RunnerRecord.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/RunnerRecord.java
@@ -45,16 +45,10 @@ public class RunnerRecord implements Comparable<RunnerRecord> {
         final double movingDistanceMeter = this.gpsData.calculateDistance(gpsData);
         final double durationSeconds = this.gpsData.calculateDuration(gpsData);
 
-        if (durationSeconds == MIN_DURATION_SECOND) {
+        if (durationSeconds == MIN_DURATION_SECOND || MAXIMUM_RUNNER_SPEED_OF_METERS_PER_SECOND < movingDistanceMeter / durationSeconds) {
             return Optional.empty();
         }
-
-        final double runnerSpeedOfMetersPerSecond = movingDistanceMeter / durationSeconds;
-        if (MAXIMUM_RUNNER_SPEED_OF_METERS_PER_SECOND >= runnerSpeedOfMetersPerSecond) {
-            return Optional.of(new RunnerRecord(gpsData, this.distance + movingDistanceMeter));
-        }
-
-        return Optional.empty();
+        return Optional.of(new RunnerRecord(gpsData, this.distance + movingDistanceMeter));
     }
 
     public boolean hasBiggerDistanceThan(int targetDistance) {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -1,11 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.acceptanceTest;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.jwtmanager.JwtGenerator;
 import online.partyrun.partyrunbattleservice.acceptance.AcceptanceTest;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
@@ -18,7 +12,6 @@ import online.partyrun.partyrunbattleservice.domain.battle.repository.BattleRepo
 import online.partyrun.partyrunbattleservice.domain.member.entity.Member;
 import online.partyrun.partyrunbattleservice.domain.member.repository.MemberRepository;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
@@ -40,18 +33,29 @@ import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.TimeUnit;
 
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 @Import({WebSocketTestConfiguration.class, TestTimeConfig.class})
 @DisplayName("BattleWebSocketAcceptance")
 public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
     private static final String TOPIC_BATTLE_PREFIX = "/topic/battles";
     private static final String PUB_BATTLE_PREFIX = "/pub/battles";
 
-    @Autowired WebSocketStompClient webSocketStompClient;
-    @Autowired BattleRepository battleRepository;
-    @Autowired MemberRepository memberRepository;
-    @Autowired MongoTemplate mongoTemplate;
-    @Autowired JwtGenerator jwtGenerator;
-    @Autowired Clock clock;
+    @Autowired
+    WebSocketStompClient webSocketStompClient;
+    @Autowired
+    BattleRepository battleRepository;
+    @Autowired
+    MemberRepository memberRepository;
+    @Autowired
+    MongoTemplate mongoTemplate;
+    @Autowired
+    JwtGenerator jwtGenerator;
+    @Autowired
+    Clock clock;
     Battle 배틀;
     StompSession 박성우_Session;
     StompSession 박현준_Session;
@@ -60,8 +64,8 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
     BlockingQueue<BattleWebSocketResponse> 박현준_Queue;
     BlockingQueue<BattleWebSocketResponse> 노준혁_Queue;
 
-    private Runner 러너_생성(Member 멤버박성우) {
-        return new Runner(memberRepository.save(멤버박성우).getId());
+    private Runner 러너_생성(Member member) {
+        return new Runner(memberRepository.save(member).getId());
     }
 
     private String 토큰_생성(Runner 노준혁) {
@@ -77,7 +81,8 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                     .connectAsync(
                             "ws://localhost:" + port + "/api/ws/battles/connection",
                             headers,
-                            new StompSessionHandlerAdapter() {})
+                            new StompSessionHandlerAdapter() {
+                            })
                     .get(1, TimeUnit.SECONDS);
         } catch (Exception e) {
             throw new RuntimeException();
@@ -109,9 +114,7 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
         박현준_Session = 웹소켓_연결(박현준_accessToken);
         노준혁_Session = 웹소켓_연결(노준혁_accessToken);
 
-        배틀 =
-                battleRepository.save(
-                        new Battle(1000, List.of(박성우, 박현준, 노준혁), LocalDateTime.now(clock)));
+        배틀 = battleRepository.save(new Battle(10, List.of(박성우, 박현준, 노준혁), LocalDateTime.now(clock)));
 
         박성우_Queue = new LinkedBlockingDeque<>();
         박현준_Queue = new LinkedBlockingDeque<>();
@@ -186,11 +189,8 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                                         .isEqualTo(박현준_response)
                                         .isEqualTo(노준혁_response),
                         () ->
-                                assertThat(박성우_response.getData().get("startTime"))
-                                        .isEqualTo(
-                                                LocalDateTime.now(clock)
-                                                        .plusSeconds(5)
-                                                        .toString()));
+                                assertThat(박성우_response.getData())
+                                        .containsEntry("startTime", LocalDateTime.now(clock).plusSeconds(5).toString()));
             }
         }
 
@@ -214,6 +214,19 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 러너들의_기록을_저장할_때 {
         LocalDateTime now = LocalDateTime.now();
+        LocalDateTime gpsTime = now.plusMinutes(1);
+        GpsRequest GPS_REQUEST1 = new GpsRequest(0, 0, 0, gpsTime);
+        GpsRequest GPS_REQUEST2 = new GpsRequest(0.00001, 0.00001, 0.00001, gpsTime.plusSeconds(1));
+        GpsRequest GPS_REQUEST3 = new GpsRequest(0.00002, 0.00002, 0.00002, gpsTime.plusSeconds(2));
+        RunnerRecordRequest RECORD_REQUEST1 = new RunnerRecordRequest(List.of(GPS_REQUEST1, GPS_REQUEST2, GPS_REQUEST3));
+        GpsRequest GPS_REQUEST4 = new GpsRequest(0.00003, 0.00003, 0.00003, gpsTime.plusSeconds(3));
+        GpsRequest GPS_REQUEST5 = new GpsRequest(0.00004, 0.00004, 0.00004, gpsTime.plusSeconds(4));
+        GpsRequest GPS_REQUEST6 = new GpsRequest(0.00005, 0.00005, 0.00005, gpsTime.plusSeconds(5));
+        RunnerRecordRequest RECORD_REQUEST2 = new RunnerRecordRequest(List.of(GPS_REQUEST4, GPS_REQUEST5, GPS_REQUEST6));
+        GpsRequest GPS_REQUEST7 = new GpsRequest(0.00006, 0.00006, 0.00006, gpsTime.plusSeconds(6));
+        GpsRequest GPS_REQUEST8 = new GpsRequest(0.00007, 0.00007, 0.00007, gpsTime.plusSeconds(7));
+        GpsRequest GPS_REQUEST9 = new GpsRequest(0.00008, 0.00008, 0.00008, gpsTime.plusSeconds(8));
+        RunnerRecordRequest RECORD_REQUEST3 = new RunnerRecordRequest(List.of(GPS_REQUEST7, GPS_REQUEST8, GPS_REQUEST9));
 
         @BeforeEach
         void setUpData() throws InterruptedException {
@@ -235,23 +248,6 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
             mongoTemplate.updateFirst(query, Update.update("startTime", now), Battle.class);
         }
 
-        LocalDateTime gpsTime = now.plusMinutes(1);
-        GpsRequest GPS_REQUEST1 = new GpsRequest(0, 0, 0, gpsTime);
-        GpsRequest GPS_REQUEST2 = new GpsRequest(0.001, 0.001, 0.001, gpsTime.plusSeconds(1));
-        GpsRequest GPS_REQUEST3 = new GpsRequest(0.002, 0.002, 0.002, gpsTime.plusSeconds(2));
-        GpsRequest GPS_REQUEST4 = new GpsRequest(0.003, 0.003, 0.003, gpsTime.plusSeconds(3));
-        GpsRequest GPS_REQUEST5 = new GpsRequest(0.004, 0.004, 0.004, gpsTime.plusSeconds(4));
-        GpsRequest GPS_REQUEST6 = new GpsRequest(0.005, 0.005, 0.005, gpsTime.plusSeconds(5));
-        GpsRequest GPS_REQUEST7 = new GpsRequest(0.006, 0.006, 0.006, gpsTime.plusSeconds(6));
-        GpsRequest GPS_REQUEST8 = new GpsRequest(0.007, 0.007, 0.007, gpsTime.plusSeconds(7));
-        GpsRequest GPS_REQUEST9 = new GpsRequest(0.008, 0.008, 0.008, gpsTime.plusSeconds(8));
-        RunnerRecordRequest RECORD_REQUEST1 =
-                new RunnerRecordRequest(List.of(GPS_REQUEST1, GPS_REQUEST2, GPS_REQUEST3));
-        RunnerRecordRequest RECORD_REQUEST2 =
-                new RunnerRecordRequest(List.of(GPS_REQUEST4, GPS_REQUEST5, GPS_REQUEST6));
-        RunnerRecordRequest RECORD_REQUEST3 =
-                new RunnerRecordRequest(List.of(GPS_REQUEST7, GPS_REQUEST8, GPS_REQUEST9));
-
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
         class 좌표를_받으면 {
@@ -269,15 +265,15 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                 좌표_보내기_요청(노준혁_Session, RECORD_REQUEST1);
                 좌표_보내기_요청(박현준_Session, RECORD_REQUEST1);
 
-                BattleWebSocketResponse 박성우_response1 = 박성우_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 박성우_response2 = 박성우_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 박성우_response3 = 박성우_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 박현준_response1 = 박현준_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 박현준_response2 = 박현준_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 박현준_response3 = 박현준_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 노준혁_response1 = 노준혁_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 노준혁_response2 = 노준혁_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 노준혁_response3 = 노준혁_Queue.poll(1, TimeUnit.SECONDS);
+                BattleWebSocketResponse 박성우_response1 = 박성우_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 박성우_response2 = 박성우_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 박성우_response3 = 박성우_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 박현준_response1 = 박현준_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 박현준_response2 = 박현준_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 박현준_response3 = 박현준_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 노준혁_response1 = 노준혁_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 노준혁_response2 = 노준혁_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 노준혁_response3 = 노준혁_Queue.poll(500, TimeUnit.MILLISECONDS);
 
                 assertThat(List.of(박성우_response1, 박성우_response2, 박성우_response3))
                         .containsAll(List.of(노준혁_response1, 노준혁_response2, 노준혁_response3))
@@ -293,58 +289,30 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                 Thread.sleep(300);
                 좌표_보내기_요청(박성우_Session, RECORD_REQUEST3);
 
-                BattleWebSocketResponse 박성우_response1 = 박성우_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 박성우_response2 = 박성우_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 박성우_response3 = 박성우_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 박성우_response4 = 박성우_Queue.poll(1, TimeUnit.SECONDS);
-
-                BattleWebSocketResponse 박현준_response1 = 박현준_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 박현준_response2 = 박현준_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 박현준_response3 = 박현준_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 박현준_response4 = 박현준_Queue.poll(1, TimeUnit.SECONDS);
-
-                BattleWebSocketResponse 노준혁_response1 = 노준혁_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 노준혁_response2 = 노준혁_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 노준혁_response3 = 노준혁_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 노준혁_response4 = 노준혁_Queue.poll(1, TimeUnit.SECONDS);
+                BattleWebSocketResponse 박성우_response1 = 박성우_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 박성우_response2 = 박성우_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 박성우_response3 = 박성우_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 박성우_response4 = 박성우_Queue.poll(500, TimeUnit.MILLISECONDS);
+                
+                BattleWebSocketResponse 박현준_response1 = 박현준_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 박현준_response2 = 박현준_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 박현준_response3 = 박현준_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 박현준_response4 = 박현준_Queue.poll(500, TimeUnit.MILLISECONDS);
+                
+                BattleWebSocketResponse 노준혁_response1 = 노준혁_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 노준혁_response2 = 노준혁_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 노준혁_response3 = 노준혁_Queue.poll(500, TimeUnit.MILLISECONDS);
+                BattleWebSocketResponse 노준혁_response4 = 노준혁_Queue.poll(500, TimeUnit.MILLISECONDS);
 
                 final List<BattleWebSocketResponse> responses =
                         List.of(박성우_response1, 박성우_response2, 박성우_response3, 박성우_response4);
                 assertAll(
-                        () ->
-                                assertThat(responses)
-                                        .containsAll(
-                                                List.of(
-                                                        노준혁_response1,
-                                                        노준혁_response2,
-                                                        노준혁_response3,
-                                                        노준혁_response4))
-                                        .containsAll(
-                                                List.of(
-                                                        박현준_response1,
-                                                        박현준_response2,
-                                                        박현준_response3,
-                                                        박현준_response4)),
-                        () ->
-                                assertThat(
-                                                responses.stream()
-                                                        .filter(
-                                                                battleWebSocketResponse ->
-                                                                        battleWebSocketResponse
-                                                                                .getType()
-                                                                                .equals(
-                                                                                        "BATTLE_RUNNING")))
-                                        .hasSize(3),
-                        () ->
-                                assertThat(
-                                                responses.stream()
-                                                        .filter(
-                                                                battleWebSocketResponse ->
-                                                                        battleWebSocketResponse
-                                                                                .getType()
-                                                                                .equals(
-                                                                                        "RUNNER_FINISHED")))
-                                        .hasSize(1));
+                        () -> assertThat(responses).containsAll(List.of(노준혁_response1, 노준혁_response2, 노준혁_response3, 노준혁_response4))
+                                .containsAll(List.of(박현준_response1, 박현준_response2, 박현준_response3, 박현준_response4)),
+                        () -> assertThat(responses.stream().filter(battleWebSocketResponse -> battleWebSocketResponse.getType().equals("BATTLE_RUNNING")))
+                                .hasSize(3),
+                        () -> assertThat(responses.stream().filter(battleWebSocketResponse -> battleWebSocketResponse.getType().equals("RUNNER_FINISHED")))
+                                .hasSize(1));
             }
 
             @Test
@@ -357,12 +325,9 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                 BattleWebSocketResponse response2 = 박성우_Queue.poll(300, TimeUnit.MILLISECONDS);
 
                 assertAll(
-                        () ->
-                                assertThat(Objects.isNull(response1) && Objects.isNull(response2))
-                                        .isFalse(),
-                        () ->
-                                assertThat(Objects.isNull(response1) || Objects.isNull(response2))
-                                        .isTrue());
+                        () -> assertThat(Objects.isNull(response1) && Objects.isNull(response2)).isFalse(),
+                        () -> assertThat(Objects.isNull(response1) || Objects.isNull(response2)).isTrue()
+                );
             }
         }
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/entity/BattleTest.java
@@ -1,7 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.entity;
 
-import static org.assertj.core.api.Assertions.*;
-
 import online.partyrun.partyrunbattleservice.domain.battle.exception.*;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
@@ -9,7 +7,6 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataTimeException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerNotFoundException;
-
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullAndEmptySource;
@@ -18,6 +15,10 @@ import org.junit.jupiter.params.provider.ValueSource;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static online.partyrun.partyrunbattleservice.fixture.GpsDataFixture.*;
+import static online.partyrun.partyrunbattleservice.fixture.LocalDateTimeFixture.now;
+import static org.assertj.core.api.Assertions.*;
+
 @DisplayName("Battle")
 class BattleTest {
 
@@ -25,7 +26,13 @@ class BattleTest {
     Runner 노준혁;
     Runner 박현준;
     Battle 배틀;
-    LocalDateTime now = LocalDateTime.now();
+
+    @BeforeEach
+    void setUp() {
+        박성우 = new Runner("박성우");
+        노준혁 = new Runner("노준혁");
+        박현준 = new Runner("박현준");
+    }
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -35,9 +42,6 @@ class BattleTest {
 
         @BeforeEach
         void setUp() {
-            박성우 = new Runner("박성우");
-            노준혁 = new Runner("노준혁");
-            박현준 = new Runner("박현준");
             runnerList = List.of(박성우, 노준혁, 박현준);
         }
 
@@ -98,9 +102,6 @@ class BattleTest {
 
         @BeforeEach
         void setUp() {
-            박성우 = new Runner("박성우");
-            노준혁 = new Runner("노준혁");
-            박현준 = new Runner("박현준");
             배틀 = new Battle(1000, List.of(박성우, 박현준), now);
         }
 
@@ -130,7 +131,6 @@ class BattleTest {
 
         @BeforeEach
         void setUp() {
-            박성우 = new Runner("박성우");
             배틀 = new Battle(1000, List.of(박성우), now);
         }
 
@@ -163,7 +163,6 @@ class BattleTest {
 
         @BeforeEach
         void setUp() {
-            박성우 = new Runner("박성우");
             배틀 = new Battle(1000, List.of(박성우), now);
         }
 
@@ -207,8 +206,6 @@ class BattleTest {
 
         @BeforeEach
         void setUp() {
-            박성우 = new Runner("박성우");
-            박현준 = new Runner("박현준");
             배틀 = new Battle(1000, List.of(박성우, 박현준), now);
         }
 
@@ -248,7 +245,6 @@ class BattleTest {
 
         @BeforeEach
         void setUp() {
-            박성우 = new Runner("박성우");
             배틀 = new Battle(1000, List.of(박성우), now);
 
             박성우.changeRunningStatus();
@@ -287,9 +283,7 @@ class BattleTest {
         @Test
         @DisplayName("새로운 기록을 만든다.")
         void createNewRecords() {
-            GpsData gpsData1 = GpsData.of(1, 1, 1, battleStartTime.plusSeconds(1));
-            GpsData gpsData2 = GpsData.of(2, 2, 2, battleStartTime.plusSeconds(2));
-            List<GpsData> gpsData = List.of(gpsData1, gpsData2);
+            List<GpsData> gpsData = List.of(GPSDATA1, GPSDATA2);
 
             배틀.addRecords(박성우.getId(), gpsData);
 
@@ -318,21 +312,16 @@ class BattleTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 러너의_최신_거리를_가져올_때 {
-        LocalDateTime battleStartTime;
 
         @BeforeEach
         void setUp() {
-            박성우 = new Runner("박성우");
             배틀 = new Battle(1000, List.of(박성우), now);
 
             박성우.changeRunningStatus();
 
-            battleStartTime = LocalDateTime.now();
-            배틀.setStartTime(battleStartTime.minusSeconds(5));
+            배틀.setStartTime(now.minusSeconds(5));
 
-            GpsData gpsData1 = GpsData.of(1, 1, 1, battleStartTime.plusSeconds(1));
-            GpsData gpsData2 = GpsData.of(2, 2, 2, battleStartTime.plusSeconds(2));
-            List<GpsData> gpsData = List.of(gpsData1, gpsData2);
+            List<GpsData> gpsData = List.of(GPSDATA1, GPSDATA2);
             배틀.addRecords(박성우.getId(), gpsData);
         }
 
@@ -348,48 +337,39 @@ class BattleTest {
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 배틀의_러너들을_랭크순으로_정렬할_때 {
 
-        GpsData gpsData0 = GpsData.of(0, 0, 0, now.plusSeconds(1));
-        GpsData gpsData1 = GpsData.of(0.001, 0.001, 0, now.plusSeconds(2));
-        GpsData gpsData2 = GpsData.of(0.002, 0.002, 0, now.plusSeconds(3));
-        GpsData gpsData3 = GpsData.of(0.0003, 0.0003, 0, now.plusSeconds(4));
-        GpsData gpsData4 = GpsData.of(0.0004, 0.0004, 0, now.plusSeconds(5));
-        GpsData gpsData5 = GpsData.of(0.0005, 0.0005, 0, now.plusSeconds(6));
-
         @BeforeEach
         void setUp() {
-            박성우 = new Runner("박성우");
             박성우.changeRunningStatus();
-
-            노준혁 = new Runner("노준혁");
             노준혁.changeRunningStatus();
 
-            배틀 = new Battle(100, List.of(노준혁, 박성우), now);
-            배틀.setStartTime(now.minusSeconds(5));
+            배틀 = new Battle(3, List.of(노준혁, 박성우), now);
+            배틀.setStartTime(now.minusSeconds(10));
         }
 
         @Test
-        @DisplayName("둘 다 종료 되었다면 종료된 시간에 따라 등수를 결정한다.")
+        @DisplayName("둘 다 완주하였다면, 종료된 시간에 따라 등수를 결정한다.")
         void sortedByFinishedStatus() {
-            배틀.addRecords(박성우.getId(), List.of(gpsData0, gpsData1));
-            배틀.addRecords(노준혁.getId(), List.of(gpsData0, gpsData2));
+            배틀.addRecords(박성우.getId(), List.of(GPSDATA0, GPSDATA1, GPSDATA2));
+            배틀.addRecords(노준혁.getId(), List.of(GPSDATA1, GPSDATA2, GPSDATA3));
 
             assertThat(배틀.getRunnersOrderByRank()).containsExactly(박성우, 노준혁);
         }
 
         @Test
-        @DisplayName("종료된 러너가 더 높은 등수를 갖는다.")
+        @DisplayName("완주한 러너가 더 높은 등수를 갖는다.")
         void sortedByStatus() {
-            배틀.addRecords(박성우.getId(), List.of(gpsData0, gpsData1));
-            배틀.addRecords(노준혁.getId(), List.of(gpsData0));
+            배틀.addRecords(박성우.getId(), List.of(GPSDATA0, GPSDATA1, GPSDATA2));
+            배틀.addRecords(노준혁.getId(), List.of(GPSDATA0));
+            노준혁.changeFinishStatus();
 
             assertThat(배틀.getRunnersOrderByRank()).containsExactly(박성우, 노준혁);
         }
 
         @Test
-        @DisplayName("종료된 러너가 더 높은 등수를 갖는다.2")
+        @DisplayName("완주한 러너가 더 높은 등수를 갖는다.2")
         void sortedByStatus2() {
-            배틀.addRecords(노준혁.getId(), List.of(gpsData0, gpsData1));
-            배틀.addRecords(박성우.getId(), List.of(gpsData0));
+            배틀.addRecords(노준혁.getId(), List.of(GPSDATA0, GPSDATA1, GPSDATA2));
+            배틀.addRecords(박성우.getId(), List.of(GPSDATA0));
 
             assertThat(배틀.getRunnersOrderByRank()).containsExactly(노준혁, 박성우);
         }
@@ -397,8 +377,8 @@ class BattleTest {
         @Test
         @DisplayName("종료되지 않았다면, 거리 순으로 비교한다.")
         void sortedByRunningStatus() {
-            배틀.addRecords(노준혁.getId(), List.of(gpsData0, gpsData3));
-            배틀.addRecords(박성우.getId(), List.of(gpsData3, gpsData4));
+            배틀.addRecords(노준혁.getId(), List.of(GPSDATA0, GPSDATA3));
+            배틀.addRecords(박성우.getId(), List.of(GPSDATA3, GPSDATA4));
 
             assertThat(배틀.getRunnersOrderByRank()).containsExactly(노준혁, 박성우);
         }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -1,14 +1,10 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
@@ -18,16 +14,26 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 @DataMongoTest
 @DisplayName("BattleRepository")
 class BattleRepositoryTest {
 
     @Autowired MongoTemplate mongoTemplate;
     @Autowired private BattleRepository battleRepository;
-    Runner 박성우 = new Runner("박성우");
-    Runner 박현준 = new Runner("박현준");
-    Runner 노준혁 = new Runner("노준혁");
+    Runner 박성우;
+    Runner 박현준;
+    Runner 노준혁;
     LocalDateTime now = LocalDateTime.now();
+
+    @BeforeEach
+    void setUp() {
+        박성우 = new Runner("박성우");
+        박현준 = new Runner("박현준");
+        노준혁 = new Runner("노준혁");
+    }
 
     @AfterEach
     void tearDown() {
@@ -81,7 +87,12 @@ class BattleRepositoryTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class findByRunnersIdAndRunnersStatus는 {
-        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준), now));
+        Battle 배틀;
+
+        @BeforeEach
+        void setUp() {
+            배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준), now));
+        }
 
         @Test
         @DisplayName("현재 준비 중인 배틀이 존재하면 반환한다.")
@@ -112,7 +123,12 @@ class BattleRepositoryTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class existsByIdAndRunnersIdAndRunnersStatus는 {
-        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준), now));
+        Battle 배틀;
+
+        @BeforeEach
+        void setUp() {
+            배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준), now));
+        }
 
         @Test
         @DisplayName("battleId, runnerId, status를 만족하는 데이터의 존재하면 true를 반환한다.")
@@ -141,7 +157,12 @@ class BattleRepositoryTest {
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 배틀_조회_시 {
 
-        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 노준혁), now));
+        Battle 배틀;
+
+        @BeforeEach
+        void setUp() {
+            배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 노준혁), now));
+        }
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -161,14 +182,11 @@ class BattleRepositoryTest {
             @Test
             @DisplayName("현재까지의 기록들을 반환하지 않는다.")
             void returnNullRecords() {
-                Battle result =
-                        battleRepository
+                Battle result = battleRepository
                                 .findBattleExceptRunnerRecords(배틀.getId(), 박성우.getId())
                                 .orElseThrow();
-                assertThat(
-                                result.getRunners().stream()
-                                        .allMatch(r -> r.getRunnerRecords().isEmpty()))
-                        .isTrue();
+
+                assertThat(result.getRunners().stream().allMatch(r -> r.getRunnerRecords().isEmpty())).isTrue();
             }
         }
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -1,14 +1,5 @@
 package online.partyrun.partyrunbattleservice.domain.battle.service;
 
-import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
-
-import static org.assertj.core.api.Assertions.*;
-import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.mockito.BDDMockito.then;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
-
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestApplicationContextConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.config.TestTimeConfig;
 import online.partyrun.partyrunbattleservice.domain.battle.dto.*;
@@ -24,7 +15,6 @@ import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.testmanager.redis.EnableRedisTest;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,6 +25,14 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static online.partyrun.partyrunbattleservice.fixture.MemberFixture.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.codehaus.groovy.runtime.DefaultGroovyMethods.any;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 
 @SpringBootTest
 @EnableRedisTest
@@ -65,7 +63,7 @@ class BattleServiceTest {
         장세연 = new Runner(memberRepository.save(멤버_장세연).getId());
         이승열 = new Runner(memberRepository.save(멤버_이승열).getId());
 
-        배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 노준혁), now));
+        배틀 = battleRepository.save(new Battle(10, List.of(박성우, 노준혁), now));
     }
 
     @AfterEach
@@ -271,13 +269,13 @@ class BattleServiceTest {
         Battle 진행중인_배틀;
         LocalDateTime now = LocalDateTime.now().plusMinutes(1);
         GpsRequest GPS_REQUEST0 = new GpsRequest(0, 0, 0, now);
-        GpsRequest GPS_REQUEST1 = new GpsRequest(0.001, 0.001, 0.001, now);
-        GpsRequest GPS_REQUEST2 = new GpsRequest(0.002, 0.002, 0.002, now.plusSeconds(1));
-        GpsRequest GPS_REQUEST3 = new GpsRequest(0.003, 0.003, 0.003, now.plusSeconds(2));
-        GpsRequest GPS_REQUEST4 = new GpsRequest(0.004, 0.004, 0.004, now.plusSeconds(3));
-        GpsRequest GPS_REQUEST5 = new GpsRequest(0.005, 0.005, 0.005, now.plusSeconds(4));
-        GpsRequest GPS_REQUEST6 = new GpsRequest(0.006, 0.006, 0.006, now.plusSeconds(5));
-        GpsRequest GPS_REQUEST7 = new GpsRequest(0.007, 0.007, 0.007, now.plusSeconds(6));
+        GpsRequest GPS_REQUEST1 = new GpsRequest(0.00001, 0.00001, 0.001, now);
+        GpsRequest GPS_REQUEST2 = new GpsRequest(0.00002, 0.00002, 0.002, now.plusSeconds(1));
+        GpsRequest GPS_REQUEST3 = new GpsRequest(0.00003, 0.00003, 0.003, now.plusSeconds(2));
+        GpsRequest GPS_REQUEST4 = new GpsRequest(0.00004, 0.00004, 0.004, now.plusSeconds(3));
+        GpsRequest GPS_REQUEST5 = new GpsRequest(0.00005, 0.00005, 0.005, now.plusSeconds(4));
+        GpsRequest GPS_REQUEST6 = new GpsRequest(0.00006, 0.00006, 0.006, now.plusSeconds(5));
+        GpsRequest GPS_REQUEST7 = new GpsRequest(0.00007, 0.00007, 0.007, now.plusSeconds(6));
         RunnerRecordRequest RECORD_REQUEST1 =
                 new RunnerRecordRequest(
                         List.of(GPS_REQUEST0, GPS_REQUEST1, GPS_REQUEST2, GPS_REQUEST3));
@@ -350,8 +348,8 @@ class BattleServiceTest {
             배틀.setStartTime(now.minusMinutes(1));
 
             gpsData0 = GpsData.of(0, 0, 0, now);
-            gpsData1 = GpsData.of(1, 1, 0, now.plusSeconds(1));
-            gpsData2 = GpsData.of(0.0001, 0.0001, 0, now.plusSeconds(2));
+            gpsData1 = GpsData.of(0.00001, 0.00001, 0, now.plusSeconds(1));
+            gpsData2 = GpsData.of(0.00002, 0.00002, 0, now.plusSeconds(2));
 
             배틀.addRecords(박성우.getId(), List.of(gpsData0, gpsData1));
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/RunnerTest.java
@@ -1,19 +1,19 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidRecentRunnerRecordException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotReadyException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.RunnerIsNotRunningException;
-
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
+
+import static online.partyrun.partyrunbattleservice.fixture.GpsDataFixture.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("Runner")
 class RunnerTest {
@@ -141,15 +141,10 @@ class RunnerTest {
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
     class 새로운_기록을_만들_때 {
-        LocalDateTime time = LocalDateTime.now();
-        GpsData GPSDATA_1 = GpsData.of(1, 1, 1, time);
-        GpsData GPSDATA_2 = GpsData.of(2, 2, 2, time.plusSeconds(1));
-        GpsData GPSDATA_3 = GpsData.of(3, 3, 3, time.plusSeconds(2));
-
         @Test
         @DisplayName("러너가 RUNNING 상태가 아니면 예외를 던진다.")
         void throwException() {
-            List<GpsData> gpsData = List.of(GPSDATA_1, GPSDATA_2, GPSDATA_3);
+            List<GpsData> gpsData = List.of(GPSDATA1, GPSDATA2, GPSDATA3);
             assertThatThrownBy(() -> 박성우.addRecords(gpsData))
                     .isInstanceOf(RunnerIsNotRunningException.class);
         }
@@ -159,11 +154,11 @@ class RunnerTest {
         void createRecordWithoutRecentRecord() {
             박성우.changeRunningStatus();
 
-            List<GpsData> gpsData = List.of(GPSDATA_1, GPSDATA_2, GPSDATA_3);
+            List<GpsData> gpsData = List.of(GPSDATA1, GPSDATA2, GPSDATA3);
             박성우.addRecords(gpsData);
 
             assertAll(
-                    () -> assertThat(박성우.getRecentRunnerRecord().getGpsData()).isEqualTo(GPSDATA_3),
+                    () -> assertThat(박성우.getRecentRunnerRecord().getGpsData()).isEqualTo(GPSDATA3),
                     () ->
                             assertThat(
                                             박성우.getRunnerRecords().stream()
@@ -178,14 +173,14 @@ class RunnerTest {
         void createRecordWithRecentRecord() {
             박성우.changeRunningStatus();
 
-            List<GpsData> recentGpsData = List.of(GPSDATA_1);
+            List<GpsData> recentGpsData = List.of(GPSDATA1);
             박성우.addRecords(recentGpsData);
 
-            List<GpsData> newGpsData = List.of(GPSDATA_2, GPSDATA_3);
+            List<GpsData> newGpsData = List.of(GPSDATA2, GPSDATA3);
             박성우.addRecords(newGpsData);
 
             assertAll(
-                    () -> assertThat(박성우.getRecentRunnerRecord().getGpsData()).isEqualTo(GPSDATA_3),
+                    () -> assertThat(박성우.getRecentRunnerRecord().getGpsData()).isEqualTo(GPSDATA3),
                     () ->
                             assertThat(
                                             박성우.getRunnerRecords().stream()
@@ -212,10 +207,8 @@ class RunnerTest {
         @DisplayName("최신 기록이 있으면 최신 거리를 조회한다.")
         void returnDistance() {
             박성우.changeRunningStatus();
-            GpsData GPSDATA_1 = GpsData.of(1, 1, 1, LocalDateTime.now());
-            GpsData GPSDATA_2 = GpsData.of(2, 2, 2, LocalDateTime.now().plusSeconds(1));
 
-            List<GpsData> recentGpsData = List.of(GPSDATA_1, GPSDATA_2);
+            List<GpsData> recentGpsData = List.of(GPSDATA1, GPSDATA2);
 
             박성우.addRecords(recentGpsData);
 
@@ -232,15 +225,13 @@ class RunnerTest {
         void returnEndTime() {
             박성우.changeRunningStatus();
             LocalDateTime now = LocalDateTime.now();
-            GpsData GPSDATA_1 = GpsData.of(1, 1, 1, now);
-            GpsData GPSDATA_2 = GpsData.of(2, 2, 2, now.plusSeconds(1));
 
-            List<GpsData> recentGpsData = List.of(GPSDATA_1, GPSDATA_2);
+            List<GpsData> recentGpsData = List.of(GPSDATA1, GPSDATA2);
 
             박성우.addRecords(recentGpsData);
             박성우.changeFinishStatus();
 
-            assertThat(박성우.getLastRecordTime()).isEqualTo(now.plusSeconds(1));
+            assertThat(박성우.getLastRecordTime()).isEqualTo(GPSDATA2.getTime());
         }
 
         @Test

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/GpsDataTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/runner/entity/record/GpsDataTest.java
@@ -1,23 +1,23 @@
 package online.partyrun.partyrunbattleservice.domain.runner.entity.record;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import online.partyrun.partyrunbattleservice.domain.runner.exception.GpsTimeNullException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.InvalidGpsDataException;
 import online.partyrun.partyrunbattleservice.domain.runner.exception.PastGpsDataTimeException;
-
 import org.junit.jupiter.api.*;
 
 import java.time.LocalDateTime;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 @DisplayName("GpsData")
 class GpsDataTest {
     LocalDateTime time = LocalDateTime.now();
-    GpsData GPSDATA_0 = GpsData.of(1, 1, 1, time);
-    GpsData GPSDATA_1 = GpsData.of(1, 1, 1, time.plusSeconds(1));
-    GpsData GPSDATA_2 = GpsData.of(2, 2, 2, time.plusSeconds(2));
+    int durationNano = 500_000_000;
+    GpsData GPSDATA_0 = GpsData.of(0, 0, 1, time);
+    GpsData GPSDATA_1 = GpsData.of(0.0001, 0.0001, 1, time.plusNanos(durationNano * 2L));
+    GpsData GPSDATA_2 = GpsData.of(0.0002, 0.0002, 2, time.plusNanos(durationNano * 3L));
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -83,5 +83,22 @@ class GpsDataTest {
     void throwException() {
         assertThatThrownBy(() -> GpsData.of(1, 1, 1, null))
                 .isInstanceOf(GpsTimeNullException.class);
+    }
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class GpsData_사이의_시간을_측정_시 {
+
+        @Test
+        @DisplayName("소숫점의 초 단위로 반환한다.")
+        void returnDuration() {
+            final double duration1 = GPSDATA_0.calculateDuration(GPSDATA_1);
+            final double duration2 = GPSDATA_1.calculateDuration(GPSDATA_2);
+
+            assertAll(
+                    () -> assertThat(duration1).isEqualTo(1),
+                    () ->  assertThat(duration2).isEqualTo(0.5)
+            );
+        }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/fixture/GpsDataFixture.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/fixture/GpsDataFixture.java
@@ -1,0 +1,13 @@
+package online.partyrun.partyrunbattleservice.fixture;
+
+import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
+
+import static online.partyrun.partyrunbattleservice.fixture.LocalDateTimeFixture.now;
+
+public class GpsDataFixture {
+    public static final GpsData GPSDATA0 = GpsData.of(0, 0, 0, now.plusSeconds(1));
+    public static final GpsData GPSDATA1 = GpsData.of(0.00001, 0.00001, 0, now.plusSeconds(2));
+    public static final GpsData GPSDATA2 = GpsData.of(0.00002, 0.00002, 0, now.plusSeconds(3));
+    public static final GpsData GPSDATA3 = GpsData.of(0.00003, 0.00003, 0, now.plusSeconds(4));
+    public static final GpsData GPSDATA4 = GpsData.of(0.00004, 0.00004, 0, now.plusSeconds(5));
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/fixture/LocalDateTimeFixture.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/fixture/LocalDateTimeFixture.java
@@ -1,0 +1,8 @@
+package online.partyrun.partyrunbattleservice.fixture;
+
+import java.time.LocalDateTime;
+
+public class LocalDateTimeFixture {
+
+    public static final LocalDateTime now = LocalDateTime.now();
+}


### PR DESCRIPTION
## 변경 사항
기존에는 GPS 좌표가 튀는 현상을 막지 못하였습니다.

속력 제한은 GPS 좌표 보정 과정 중, 첫 번째 작업입니다.
GPS 좌표를 통해 새로운 기록을 만들 때, 속력 제한 기능을 두어 제한 속력을 넘어가면 해당 GPS 좌표를 무시하도록 했습니다. 

Runner, RunnerRecord, GpsData 3개를 집중적으로 보면 좋을 것 같아요.
로직이 조금 더러워서 로직적으로도 신경써서 봐주세요.

## 알아야할 사항
속력 제한을 넣기 전의 테스트들은 모두 속력 제한이 없었기 때문에, 데이터 값을 모두 변경했어야했습니다.
따라서 file change가 많다고 생각이 될 것입니다.
하지만 이를 분리할 수는 없습니다.

## 테스트 방식
기존의 방식과 속력 제한 기능이 추가된 방식을 비교해야합니다.
안드로이드에서 직접 확인해야합니다.
이전 버전을 먼저 테스트하고 이 PR을 머지할 예정입니다.
