### PR TITLE
러너의 상태를 변경하는 로직 버그 해결

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -35,10 +35,8 @@ public interface BattleRepository extends MongoRepository<Battle, String> {
             RunnerRecord recentRecord,
             RunnerStatus runnerStatus);
 
-    @Query(value = "{'runners.id': ?0, 'runners.status': { $in: ?1 }}")
-    @Update("{'$set' :  {'runners.$.status': ?2}}")
-    void updateReadyOrRunningRunnerStatus(
-            String runnerId, List<RunnerStatus> preRunnerStatus, RunnerStatus runnerStatus);
+    @Query(value = "{'runners.id': ?0, 'runners.status': { $in: ?1 }}", fields = "{'runners.runnerRecords': 0}")
+    Optional<Battle> findBattleByRunnerStatus(String runnerId, List<RunnerStatus> preRunnerStatus);
 
     Optional<Battle> findByIdAndRunnersId(String battleId, String runnerId);
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleService.java
@@ -23,6 +23,7 @@ import org.springframework.stereotype.Service;
 import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -138,8 +139,8 @@ public class BattleService {
     }
 
     public MessageResponse changeRunnerFinished(String runnerId) {
-        battleRepository.updateReadyOrRunningRunnerStatus(
-                runnerId, List.of(RunnerStatus.READY, RunnerStatus.RUNNING), RunnerStatus.FINISHED);
+        final Optional<Battle> battle = battleRepository.findBattleByRunnerStatus(runnerId, List.of(RunnerStatus.READY, RunnerStatus.RUNNING));
+        battle.ifPresent(value -> battleDao.updateRunnerStatus(value.getId(), runnerId, RunnerStatus.FINISHED));
 
         return new MessageResponse("요청이 정상적으로 처리되었습니다.");
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDaoTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleDaoTest.java
@@ -1,11 +1,8 @@
 package online.partyrun.partyrunbattleservice.domain.battle.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.Runner;
 import online.partyrun.partyrunbattleservice.domain.runner.entity.RunnerStatus;
-
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,13 +10,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 @DisplayName("BattleDao")
 @SpringBootTest
 class BattleDaoTest {
 
-    @Autowired BattleDao battleDao;
+    @Autowired
+    BattleDao battleDao;
 
-    @Autowired BattleRepository battleRepository;
+    @Autowired
+    BattleRepository battleRepository;
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -27,9 +29,7 @@ class BattleDaoTest {
         Runner 박성우 = new Runner("박성우");
         Runner 박현준 = new Runner("박현준");
         Runner 노준혁 = new Runner("노준혁");
-        Battle 배틀 =
-                battleRepository.save(
-                        new Battle(1000, List.of(박성우, 박현준, 노준혁), LocalDateTime.now()));
+        Battle 배틀 = battleRepository.save(new Battle(1000, List.of(박성우, 박현준, 노준혁), LocalDateTime.now()));
 
         @Nested
         @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
@@ -38,10 +38,12 @@ class BattleDaoTest {
             @Test
             @DisplayName("배틀을 업데이트 후 반환한다.")
             void updateBattle() {
-                Battle battle =
-                        battleDao.updateRunnerStatus(배틀.getId(), 박성우.getId(), RunnerStatus.RUNNING);
-
-                assertThat(battle.getRunnerStatus(박성우.getId())).isEqualTo(RunnerStatus.RUNNING);
+                Battle battle = battleDao.updateRunnerStatus(배틀.getId(), 박현준.getId(), RunnerStatus.RUNNING);
+                assertAll(
+                        () -> assertThat(battle.getRunnerStatus(박성우.getId())).isEqualTo(RunnerStatus.READY),
+                        () -> assertThat(battle.getRunnerStatus(박현준.getId())).isEqualTo(RunnerStatus.RUNNING),
+                        () -> assertThat(battle.getRunnerStatus(노준혁.getId())).isEqualTo(RunnerStatus.READY)
+                );
             }
         }
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -244,7 +244,7 @@ class BattleRepositoryTest {
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-    class updateReadyOrRunningRunnerStatus는 {
+    class findBattleByRunnerStatus는 {
 
         Battle 배틀1;
         Battle 배틀2;
@@ -257,27 +257,35 @@ class BattleRepositoryTest {
         }
 
         @Test
-        @DisplayName("Ready 또는 Running 상태의 러너를 Finished 상태로 변경한다.")
-        void changeStatus() {
-            battleRepository.updateReadyOrRunningRunnerStatus(
+        @DisplayName("특정 상태의 러너를 가진 배틀을 조회한다.")
+        void returnBattle() {
+            final Battle battle1 = battleRepository.findBattleByRunnerStatus(
                     박성우.getId(),
-                    List.of(RunnerStatus.READY, RunnerStatus.RUNNING),
-                    RunnerStatus.FINISHED);
-            battleRepository.updateReadyOrRunningRunnerStatus(
+                    List.of(RunnerStatus.READY, RunnerStatus.RUNNING)).orElseThrow();
+            final Battle battle2 = battleRepository.findBattleByRunnerStatus(
                     노준혁.getId(),
-                    List.of(RunnerStatus.READY, RunnerStatus.RUNNING),
-                    RunnerStatus.FINISHED);
-
-            Battle result1 = battleRepository.findById(배틀1.getId()).orElseThrow();
-            Battle result2 = battleRepository.findById(배틀2.getId()).orElseThrow();
+                    List.of(RunnerStatus.READY, RunnerStatus.RUNNING)).orElseThrow();
 
             assertAll(
-                    () ->
-                            assertThat(result1.getRunnerStatus(박성우.getId()))
-                                    .isEqualTo(RunnerStatus.FINISHED),
-                    () ->
-                            assertThat(result2.getRunnerStatus(노준혁.getId()))
-                                    .isEqualTo(RunnerStatus.FINISHED));
+                    () -> assertThat(battle1.getId()).isEqualTo(배틀1.getId()),
+                    () -> assertThat(battle2.getId()).isEqualTo(배틀2.getId())
+            );
+        }
+
+        @Test
+        @DisplayName("특정 상태의 러너가 없다면 배틀을 반환하지 않는다.")
+        void returnNull() {
+            final Optional<Battle> battle1 = battleRepository.findBattleByRunnerStatus(
+                    박성우.getId(),
+                    List.of(RunnerStatus.FINISHED));
+            final Optional<Battle> battle2 = battleRepository.findBattleByRunnerStatus(
+                    노준혁.getId(),
+                    List.of(RunnerStatus.FINISHED));
+
+            assertAll(
+                    () -> assertThat(battle1).isEmpty(),
+                    () -> assertThat(battle2).isEmpty()
+            );
         }
     }
 }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -382,8 +382,14 @@ class BattleServiceTest {
 
         @Test
         void changeRunnerFinished() {
-            MessageResponse response = battleService.changeRunnerFinished("박성우");
-            assertThat(response).isNotNull();
+            MessageResponse response = battleService.changeRunnerFinished(노준혁.getId());
+
+            final Battle battle = battleRepository.findById(배틀.getId()).get();
+            Assertions.assertAll(
+                    () -> assertThat(response).isInstanceOf(MessageResponse.class),
+                    () -> assertThat(battle.getRunnerStatus(노준혁.getId())).isEqualTo(RunnerStatus.FINISHED),
+                    () -> assertThat(battle.getRunnerStatus(박성우.getId())).isEqualTo(RunnerStatus.READY)
+            );
         }
     }
 }


### PR DESCRIPTION
## 변경 사항
기존에 러너의 상태를 변경하기 위해 사용했던 메서드는 아래와 같습니다.

```java
@Query(value = "{'runners.id': ?0, 'runners.status': { $in: ?1 }}")
@Update("{'$set' :  {'runners.$.status': ?2}}")
void updateReadyOrRunningRunnerStatus(
        String runnerId, List<RunnerStatus> preRunnerStatus, RunnerStatus runnerStatus);
```

1. @Query(value = "{'runners.id': ?0, 'runners.status': { $in: ?1 }}") 를 통해서 Battle을 찾는다.
2. @Update("{'$set' :  {'runners.$.status': ?2}}") 를 통해서 조회된 Battle의 첫 번째 Runner의 status를 변경한다.

이전에는 이 쿼리가 runners.id에 해당하는 runner의 상태를 변경할 것이라고 예상했습니다.
하지만 첫 번째 Runner의 status만 변경했고, 따라서이를 사용하지않게 되었습니다.

## 알아야할 사항


1. 하나의 쿼리로 수정 시도
```java
public void updateRunnerStatus(String runnerId, List<RunnerStatus> preStatus, RunnerStatus runnerStatus) {
    Query query = Query.query(where("runners").elemMatch(where("id").is(runnerId).and("status").in(preStatus)));

    Update update = new Update()
            .set("runners.$[elem].status", runnerStatus)
            .filterArray(where("elem.id").is(runnerId));

    mongoTemplate.updateMulti(query, update, Battle.class);
}
```
처음에는 위와 같은 방식으로 수정을 시도해보았습니다.
MongoDB의 ArrayFilters를 사용하여 수정해보려고 했습니다. 위 메서드를 실행했을 때, 아래처럼 쿼리가 실행됩니다.

```
{ "runners._id" : "노준혁", "runners.status" : { "$in" : ["READY", "RUNNING"]}} and update: { "$set" : { "runners.$.status" : "FINISHED"}} in collection: battle
```

하지만 결과를 조회해보니 status가 변경되지 않았습니다. 이유를 모르겠습니다.

따라서 두 개의 쿼리로 분리하였습니다.
1. 배틀을 조회
2. 조회된 battle의 id를 이용하여, 기존에 사용하던 updateRunnerStatus 를 통해 status 변경

자세한 사항은 테스트 코드를 더 꼼꼼하게 작성했기 때문에 확인해주세요.
