### PR TITLE
러너들의 id와 상태를 통해 조건에 맞는 배틀이 존재하는지 확인한다.

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/WebSocketEventListener.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/event/WebSocketEventListener.java
@@ -1,0 +1,52 @@
+package online.partyrun.partyrunbattleservice.domain.battle.event;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import lombok.extern.slf4j.Slf4j;
+import online.partyrun.partyrunbattleservice.domain.battle.service.BattleService;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.messaging.*;
+
+import java.util.Objects;
+
+@Slf4j
+@Async
+@Component
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class WebSocketEventListener {
+
+    BattleService battleService;
+
+    @EventListener
+    public void handleWebSocketSessionConnectEvent(SessionConnectEvent event) {
+        writeLog(event.getUser().getName(), "Connect");
+    }
+
+    @EventListener
+    public void handleWebSocketSessionConnectedEvent(SessionConnectedEvent event) {
+        writeLog(event.getUser().getName(), "Connected");
+    }
+
+    @EventListener
+    public void handleWebSocketSessionSubscribeEvent(SessionSubscribeEvent event) {
+        writeLog(event.getUser().getName(), "Subscribe");
+    }
+
+    @EventListener
+    public void handleWebSocketSessionUnsubscribeEvent(SessionUnsubscribeEvent event) {
+        writeLog(event.getUser().getName(), "Unsubscribe");
+    }
+
+    @EventListener
+    public void handleWebSocketSessionDisconnectEvent(SessionDisconnectEvent event) {
+        writeLog(event.getUser().getName(), "Disconnected");
+    }
+
+    private void writeLog(String memberId, String status) {
+        log.info(String.format("멤버 : %s, 웹소켓 상태 : %s", memberId, status));
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -15,8 +15,6 @@ public interface BattleRepository extends MongoRepository<Battle, String> {
     boolean existsByIdAndRunnersIdAndRunnersStatus(
             String battleId, String runnerId, RunnerStatus status);
 
-    boolean existsByRunnersAndRunnersStatusIn(String runnerId, List<RunnerStatus> ready);
-
     boolean existsByRunnersIdInAndRunnersStatusIn(List<String> runnersId, List<RunnerStatus> ready);
 
     Optional<Battle> findByRunnersIdAndRunnersStatus(String runnerId, RunnerStatus runnerStatus);

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepository.java
@@ -15,8 +15,12 @@ public interface BattleRepository extends MongoRepository<Battle, String> {
     boolean existsByIdAndRunnersIdAndRunnersStatus(
             String battleId, String runnerId, RunnerStatus status);
 
-    boolean existsByRunnersIdInAndRunnersStatusIn(List<String> runnersId, List<RunnerStatus> ready);
+    @Query(value = "{'runners': {'$elemMatch': {'_id': {'$in': ?0}, 'status': {'$in': ?1}}}}", fields = "{'runners.runnerRecords': 0}")
+    List<Battle> findByRunnersIdInAndRunnersStatusIn(List<String> runnersId, List<RunnerStatus> runnerStatuses);
 
+    default boolean existsByRunnersIdInAndRunnersStatusIn(List<String> runnersId, List<RunnerStatus> runnerStatuses) {
+        return !findByRunnersIdInAndRunnersStatusIn(runnersId, runnerStatuses).isEmpty();
+    }
     Optional<Battle> findByRunnersIdAndRunnersStatus(String runnerId, RunnerStatus runnerStatus);
 
     @Query(value = "{ 'id': ?0, 'runners.id': ?1 }", fields = "{'runners.runnerRecords': 0}")

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/repository/BattleRepositoryTest.java
@@ -82,6 +82,21 @@ class BattleRepositoryTest {
 
             assertThat(actual).isTrue();
         }
+
+        @Test
+        @DisplayName("러너가 속한 모든 배틀이 이미 종료되었다면 READY, RUNNING으로 조회 시 false를 반환한다.")
+        void returnFalseOneRunner() {
+            노준혁.changeRunningStatus();
+            노준혁.changeFinishStatus();
+
+            final Battle 배틀 = battleRepository.save(new Battle(1000, List.of(노준혁), now));
+
+            boolean actual = battleRepository.existsByRunnersIdInAndRunnersStatusIn(
+                            List.of(박성우.getId(), 박현준.getId(), 노준혁.getId()),
+                            List.of(RunnerStatus.READY, RunnerStatus.RUNNING));
+
+            assertThat(actual).isFalse();
+        }
     }
 
     @Nested

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/service/BattleServiceTest.java
@@ -381,7 +381,8 @@ class BattleServiceTest {
     class 러너의_상태를_종료할_때 {
 
         @Test
-        void changeRunnerFinished() {
+        @DisplayName("준비 상태의 러너를 종료한다.")
+        void changeReadyRunnerFinished() {
             MessageResponse response = battleService.changeRunnerFinished(노준혁.getId());
 
             final Battle battle = battleRepository.findById(배틀.getId()).get();
@@ -389,6 +390,22 @@ class BattleServiceTest {
                     () -> assertThat(response).isInstanceOf(MessageResponse.class),
                     () -> assertThat(battle.getRunnerStatus(노준혁.getId())).isEqualTo(RunnerStatus.FINISHED),
                     () -> assertThat(battle.getRunnerStatus(박성우.getId())).isEqualTo(RunnerStatus.READY)
+            );
+        }
+
+        @Test
+        @DisplayName("러닝 상태의 러너를 종료한다.")
+        void changeRunningRunnerFinished() {
+            battleService.setRunnerRunning(배틀.getId(), 노준혁.getId());
+            battleService.setRunnerRunning(배틀.getId(), 박성우.getId());
+
+            MessageResponse response = battleService.changeRunnerFinished(노준혁.getId());
+
+            final Battle battle = battleRepository.findById(배틀.getId()).get();
+            Assertions.assertAll(
+                    () -> assertThat(response).isInstanceOf(MessageResponse.class),
+                    () -> assertThat(battle.getRunnerStatus(노준혁.getId())).isEqualTo(RunnerStatus.FINISHED),
+                    () -> assertThat(battle.getRunnerStatus(박성우.getId())).isEqualTo(RunnerStatus.RUNNING)
             );
         }
     }


### PR DESCRIPTION
## 변경 사항

배틀 생성 시, runner들 중, READY 상태나 RUNNING 상태인 러너가 존재한다면 배틀이 생성될 수 없도록 하는 로직 중, 
existsByRunnersIdInAndRunnersStatusIn 쿼리에 문제가 있었습니다.


아래처럼 배틀 도큐먼트가 존재한다고 가정해보겠습니다.
```
배틀 {
    러너 : [
        { 
           id : 박성우,
           status: RUNNING
        },
        {
           id: 노준혁,
           status: FINISHED
        }
    ]
}
```

노준혁이 FINISHED 라면 `existsByRunnersIdInAndRunnersStatusIn(["박현준", "노준혁"],  ["READY", "RUNNING"])` 가 false를 반환하는 것을 기대했습니다.
기존의 existsByRunnersIdInAndRunnersStatusIn를 실행했을 때, 아래처럼 쿼리가 실행됩니다.
{ "runners._id" : { "$in" : ["박현준", "노준혁"]}, "runners.status" : { "$in" : ["READY", "RUNNING"]}} 

위 쿼리는 runners._id 가 ["박현준", "노준혁"] 인 Battle을 찾고, 그 Battle에서 runners의 status 중 "READY", "RUNNING" 이 존재한다면 true를 반환합니다.

즉, 아래의 배틀 도큐먼트가 존재한다면, existsByRunnersIdInAndRunnersStatusIn 이 true를 반환하는 것입니다.

따라서 mongoDB의 `elemMatch`를 사용하여 이를 해결하였습니다.

## 알아야할 사항
기존의 existsByRunnersIdInAndRunnersStatusIn를 default 메서드로 만들었습니다.
테스트나 서비스 계층의 코드를 최대한 수정하지 않기 위함입니다.

대체로 Runners가 리스트의 형식으로 저장되기때문에, 이런 버그들이 발생되고 있습니다.

BattleEventListener는 어디서 오류가 발생하는지 확인하기 위해서 추가했었습니다.
