### PR TITLE
battleInterceptor BATTLE_TOPIC_PREFIX 변경

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/BattleChannelInterceptor.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/config/BattleChannelInterceptor.java
@@ -23,7 +23,7 @@ import java.util.Objects;
 @FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
 public class BattleChannelInterceptor implements ChannelInterceptor {
 
-    private static final String BATTLE_TOPIC_PREFIX = "/topic/battle/";
+    private static final String BATTLE_TOPIC_PREFIX = "/topic/battles/";
     BattleRepository battleRepository;
 
     @Override

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleWebsocketController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleWebsocketController.java
@@ -25,12 +25,6 @@ public class BattleWebsocketController {
     BattleService battleService;
     RedisPublisher messagePublisher;
 
-    @MessageMapping("/battles/{battleId}/ready")
-    public void setRunnerRunning(@DestinationVariable String battleId, Authentication auth) {
-        final String memberId = auth.getName();
-        battleService.setRunnerRunning(battleId, memberId);
-    }
-
     @MessageMapping("/battles/{battleId}/record")
     public void calculateDistance(@DestinationVariable String battleId, Authentication auth, @Valid RunnerRecordRequest request) {
         final String runnerId = auth.getName();

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -94,10 +94,6 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                 new StompFrameHandlerImpl(queue));
     }
 
-    private void 준비완료_요청(StompSession session, Battle battle) {
-        session.send(String.format("%s/%s/ready", PUB_BATTLE_PREFIX, battle.getId()), "준비 완료");
-    }
-
     @BeforeEach
     void setUpWebSocket() {
         Runner 박성우 = 러너_생성(멤버_박성우);
@@ -156,54 +152,41 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
 
     @Nested
     @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-    class 러너들이_준비_완료_요청을_보냈을_때 {
+    class 러너들이_구독_요청을_보냈을_때 {
 
-        @Nested
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        class 모두_보냈다면 {
+        @Test
+        @DisplayName("모두_보냈다면 배틀 시작 시간을 응답한다.")
+        void getBattleStartTime() throws InterruptedException {
+            구독_요청(박성우_Session, 박성우_Queue, 배틀);
+            구독_요청(박현준_Session, 박현준_Queue, 배틀);
+            구독_요청(노준혁_Session, 노준혁_Queue, 배틀);
 
-            @BeforeEach
-            void setUp() {
-                구독_요청(박성우_Session, 박성우_Queue, 배틀);
-                구독_요청(박현준_Session, 박현준_Queue, 배틀);
-                구독_요청(노준혁_Session, 노준혁_Queue, 배틀);
+            final BattleWebSocketResponse 박성우_response = 박성우_Queue.poll(3, TimeUnit.SECONDS);
+            final BattleWebSocketResponse 박현준_response = 박현준_Queue.poll(3, TimeUnit.SECONDS);
+            final BattleWebSocketResponse 노준혁_response = 노준혁_Queue.poll(3, TimeUnit.SECONDS);
 
-                준비완료_요청(박성우_Session, 배틀);
-                준비완료_요청(박현준_Session, 배틀);
-            }
-
-            @Test
-            @DisplayName("배틀 시작 시간을 응답한다.")
-            void getBattleStartTime() throws InterruptedException {
-                준비완료_요청(노준혁_Session, 배틀);
-
-                final BattleWebSocketResponse 박성우_response = 박성우_Queue.poll(3, TimeUnit.SECONDS);
-                final BattleWebSocketResponse 박현준_response = 박현준_Queue.poll(3, TimeUnit.SECONDS);
-                final BattleWebSocketResponse 노준혁_response = 노준혁_Queue.poll(3, TimeUnit.SECONDS);
-
-                assertAll(() -> assertThat(박성우_response)
-                                .isEqualTo(박현준_response)
-                                .isEqualTo(노준혁_response)
-                                .isNotNull(),
-                        () -> assertThat(박성우_response.getData().get("startTime"))
-                                .isEqualTo(LocalDateTime.now(clock).plusSeconds(5).toString()));
-            }
+            assertAll(() -> assertThat(박성우_response)
+                            .isEqualTo(박현준_response)
+                            .isEqualTo(노준혁_response)
+                            .isNotNull(),
+                    () -> assertThat(박성우_response.getData().get("startTime"))
+                            .isEqualTo(LocalDateTime.now(clock).plusSeconds(5).toString()));
         }
 
-        @Nested
-        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
-        class 모두_보내지_않았다면 {
 
-            @Test
-            @DisplayName("응답을 받지 못한다.")
-            void getBattleStartTime() throws InterruptedException {
-                BattleWebSocketResponse 박성우_response = 박성우_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 박현준_response = 박현준_Queue.poll(1, TimeUnit.SECONDS);
-                BattleWebSocketResponse 노준혁_response = 노준혁_Queue.poll(1, TimeUnit.SECONDS);
+        @Test
+        @DisplayName("모두_보내지_않았다면 응답을 받지 못한다.")
+        void getNoResponse() throws InterruptedException {
+            구독_요청(박성우_Session, 박성우_Queue, 배틀);
+            구독_요청(박현준_Session, 박현준_Queue, 배틀);
 
-                assertThat(박성우_response).isEqualTo(박현준_response).isEqualTo(노준혁_response).isNull();
-            }
+            BattleWebSocketResponse 박성우_response = 박성우_Queue.poll(1, TimeUnit.SECONDS);
+            BattleWebSocketResponse 박현준_response = 박현준_Queue.poll(1, TimeUnit.SECONDS);
+            BattleWebSocketResponse 노준혁_response = 노준혁_Queue.poll(1, TimeUnit.SECONDS);
+
+            assertThat(박성우_response).isEqualTo(박현준_response).isEqualTo(노준혁_response).isNull();
         }
+
     }
 
 
@@ -230,10 +213,6 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
             구독_요청(박성우_Session, 박성우_Queue, 배틀);
             구독_요청(박현준_Session, 박현준_Queue, 배틀);
             구독_요청(노준혁_Session, 노준혁_Queue, 배틀);
-
-            준비완료_요청(박성우_Session, 배틀);
-            준비완료_요청(박현준_Session, 배틀);
-            준비완료_요청(노준혁_Session, 배틀);
 
             // 시작 시간 응답
             assertAll(


### PR DESCRIPTION
## 변경 사항

이전에는 구독 이후, 준비가 완료되었다는 요청을 추가로 보냈어야했습니다.

이를 구독 요청이 들어오면 interceptor에서 준비 완료를 처리하는 로직으로 변경하였습니다.
이렇게 함으로써 불필요한 로직, 트래픽을 줄이게 되었습니다.

로직에서 큰 변화는 없습니다. 컨트롤러에 존재하던 로직을 인터셉터로 옮긴 것 뿐입니다.