### PR TITLE
배틀 과정 중 예외 발생 시, 로깅 처리

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleMessageControllerAdvice.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleMessageControllerAdvice.java
@@ -1,19 +1,49 @@
 package online.partyrun.partyrunbattleservice.domain.battle.controller;
 
-import lombok.AccessLevel;
-import lombok.experimental.FieldDefaults;
 import lombok.extern.slf4j.Slf4j;
-
+import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
+import online.partyrun.partyrunbattleservice.global.exception.NotFoundException;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
-import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MissingRequestHeaderException;
+
+import java.util.stream.Collectors;
 
 @Slf4j
-@ControllerAdvice
-@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@Controller
 public class BattleMessageControllerAdvice {
 
-    @MessageExceptionHandler
-    public void handleException(Exception exception) {
-        log.warn(exception.getMessage());
+    private static final String EXCEPTION_MESSAGE = "[EXCEPTION]";
+
+    @MessageExceptionHandler({
+            BadRequestException.class,
+            HttpMessageNotReadableException.class,
+            MissingRequestHeaderException.class
+    })
+    public void handleBadRequestException(Exception exception) {
+        log.warn("{} {}", EXCEPTION_MESSAGE, exception.getMessage());
+    }
+
+    @MessageExceptionHandler(BindException.class)
+    public void handleBindException(BindException exception) {
+        final String message =
+                exception.getBindingResult().getAllErrors().stream()
+                        .map(error -> String.format("%s: %s", ((FieldError) error).getField(), error.getDefaultMessage()))
+                        .collect(Collectors.joining(", "));
+
+        log.warn("{} {}",EXCEPTION_MESSAGE, message);
+    }
+
+    @MessageExceptionHandler(NotFoundException.class)
+    public void handleNotFoundException(NotFoundException exception) {
+        log.warn("{} {}",EXCEPTION_MESSAGE, exception.getMessage());
+    }
+
+    @MessageExceptionHandler({RuntimeException.class, Exception.class})
+    public void handleInternalServerErrorException(Exception exception) {
+        log.error("{} {}", EXCEPTION_MESSAGE, exception.getMessage());
     }
 }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleMessageControllerAdvice.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/battle/controller/BattleMessageControllerAdvice.java
@@ -5,15 +5,15 @@ import online.partyrun.partyrunbattleservice.global.exception.BadRequestExceptio
 import online.partyrun.partyrunbattleservice.global.exception.NotFoundException;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
-import org.springframework.stereotype.Controller;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MissingRequestHeaderException;
+import org.springframework.web.bind.annotation.ControllerAdvice;
 
 import java.util.stream.Collectors;
 
 @Slf4j
-@Controller
+@ControllerAdvice
 public class BattleMessageControllerAdvice {
 
     private static final String EXCEPTION_MESSAGE = "[EXCEPTION]";


### PR DESCRIPTION
## 변경 사항
다른 서비스와 마찬가지로 `@ControllerAdvice`에서 예외마다의 처리를 변경했습니다.
앞으로 점차 로깅에 대해서 발전시켜나가야합니다.

예외 처리는 다른 서비스와 동일하게 진행했습니다. 

추후에는 예외가 발생하면 러너들에게 어떻게 전달할지에 대해서 고민해볼 생각입니다. 
