### PR TITLE
feat: redis cluster 연결을 prd 환경 변수 변경

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/global/config/RedissonConfig.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/config/RedissonConfig.java
@@ -6,15 +6,26 @@ import org.redisson.config.Config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import java.util.List;
 
 @Configuration
 public class RedissonConfig {
 
-    @Value("${spring.data.redis.url}")
-    private String redisUrl;
+    @Bean
+    @Profile("prd")
+    public RedissonClient clusterRedissonClient(@Value("${spring.data.redis.cluster.nodes}") List<String> nodes) {
+        Config config = new Config();
+        config.useClusterServers()
+                .addNodeAddress(nodes.toArray(new String[nodes.size()]));
+
+        return Redisson.create(config);
+    }
 
     @Bean
-    public RedissonClient redissonClient() {
+    @Profile("dev")
+    public RedissonClient singleRedissonClient(@Value("${spring.data.redis.url}") String redisUrl) {
         Config config = new Config();
         config.useSingleServer().setAddress(redisUrl);
         return Redisson.create(config);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,12 +46,45 @@ jwt:
 spring:
   config:
     activate:
-      on-profile: local, dev, prd
+      on-profile: local, dev
   data:
     mongodb:
       uri: ${DB_URI}
     redis:
       url: ${REDIS_URL}
+
+  cloud:
+    aws:
+      region:
+        static: ${AWS_SQS_REGION}
+      credentials:
+        access-key: ${AWS_SQS_ACCESS_KEY}
+        secret-key: ${AWS_SQS_SECRET_KEY}
+      sqs:
+        queue-url: ${AWS_SQS_QUEUE_URL}
+
+jwt:
+  access-secret-key: ${JWT_ACCESS_SECRET_KEY}
+  access-expire-second: ${JWT_ACCESS_EXPIRE_LENGTH}
+  refresh-secret-key: ${JWT_REFRESH_SECRET_KEY}
+  refresh-expire-second: ${JWT_REFRESH_EXPIRE_LENGTH}
+
+logging:
+  slack:
+    webhook-uri: ${SLACK_ERROR_URL}
+  config: classpath:logback-spring.xml
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prd
+  data:
+    mongodb:
+      uri: ${DB_URI}
+    redis:
+      cluster:
+        nodes: ${REDIS_CLUSTER_NODES}
 
   cloud:
     aws:

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/config/TestRedissonConfiguration.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/config/TestRedissonConfiguration.java
@@ -1,0 +1,21 @@
+package online.partyrun.partyrunbattleservice.domain.battle.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("test")
+public class TestRedissonConfiguration {
+
+    @Bean
+    public RedissonClient redissonClient(@Value("${spring.data.redis.url}") String redisUrl) {
+        Config config = new Config();
+        config.useSingleServer().setAddress(redisUrl);
+        return Redisson.create(config);
+    }
+}


### PR DESCRIPTION
## 변경 사항
production 환경에서는 redis cluster를 사용합니다.
그에 맞게 연결 방법도 변경해야합니다.
Redisson을 사용하고 있으므로 Redisson client를 수정하였습니다.

고민되는 부분은 prd와 dev환경에서 Redisson client가 다르다는 부분인데요.
test 까지는 단일 레디스로 가도 될 것 같다고 생각이 드는데,
dev 환경을 위해서 production 코드에 dev만의 bean 이 등록되는게 좀 이상해서요.
사실 dev 환경이 prd 환경과 다른 것도 좀 이상하고?

만약 dev 환경을 지금 그대로 유지한다면, 지금처럼 설정 파일을 가져가야할 것 같고,
dev 환경에서도 레디스 클러스터를 구축한다면 설정 파일을 다시 변경해야할 것 같고.

어떤게 좋을 것 같은가요?
