### PR TITLE
거리 계산 로직 수정

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/runner/entity/Runner.java
@@ -58,7 +58,9 @@ public class Runner {
         final List<RunnerRecord> newRecords = createRecords(gpsData);
 
         this.runnerRecords.addAll(newRecords);
-        this.recentRunnerRecord = Collections.max(this.runnerRecords);
+        if (!this.runnerRecords.isEmpty()) {
+            this.recentRunnerRecord = Collections.max(this.runnerRecords);
+        }
     }
 
     private void validateIsNotRunningStatus() {

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/battle/acceptanceTest/BattleWebSocketAcceptanceTest.java
@@ -319,6 +319,22 @@ public class BattleWebSocketAcceptanceTest extends AcceptanceTest {
                         () -> assertThat(Objects.isNull(response1) || Objects.isNull(response2)).isTrue()
                 );
             }
+
+            @Test
+            @DisplayName("제한 속도를 넘어가면, GPS 기록에 반영되지 않는다.")
+            void exceptExceedSpeed() throws InterruptedException {
+                좌표_보내기_요청(박성우_Session, RECORD_REQUEST1);
+                Thread.sleep(300);
+
+                GpsRequest INVALID_GPS_REQUEST = new GpsRequest(1, 1, 0, gpsTime.plusSeconds(3));
+                RunnerRecordRequest RECORD_REQUEST3 = new RunnerRecordRequest(List.of(INVALID_GPS_REQUEST, INVALID_GPS_REQUEST, INVALID_GPS_REQUEST));
+                좌표_보내기_요청(박성우_Session, RECORD_REQUEST3);
+
+                BattleWebSocketResponse response1 = 박성우_Queue.poll(1, TimeUnit.SECONDS);
+                BattleWebSocketResponse response2 = 박성우_Queue.poll(1, TimeUnit.SECONDS);
+
+                assertThat(response1).isEqualTo(response2);
+            }
         }
     }
 }


### PR DESCRIPTION
## 변경 사항

속도 제한 기능이 추가되면서 새롭게 발생한 버그가 있습니다.

기존 로직에서는 
`Collections.max(this.runnerRecords)` 를 그냥 진행하고 있었습니다.
하지만 속도 제한 기능이 추가되면서 this.runnerRecords가 null일 수 있습니다. 속도 제한에 걸린 GPS들은 Records에 추가되지 않기때문입니다.
