### PR TITLE
싱글 모드 기록을 저장한다.

### DIFF
--- a/src/docs/asciidoc/battle.adoc
+++ b/src/docs/asciidoc/battle.adoc
@@ -41,3 +41,8 @@ operation::battle not found[snippets='http-request,http-response']
 러너가 배틀이 끝나고 결과를 조회할 때 (배틀을 끝낸 러너들만 조회 대상이 된다.)
 
 operation::get finished battle[snippets='http-request,http-response']
+
+=== 싱글 기록 저장
+싱글 경기에 대한 기록을 저장할 때
+
+operation::create single[snippets='http-request,http-response']

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/single/controller/SingleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/single/controller/SingleController.java
@@ -10,10 +10,7 @@ import online.partyrun.partyrunbattleservice.domain.single.service.SingleService
 import online.partyrun.partyrunbattleservice.global.logging.Logging;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.Authentication;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Logging
 @RestController
@@ -26,7 +23,7 @@ public class SingleController {
 
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
-    public SingleIdResponse createSingle(Authentication auth, @Valid SingleRunnerRecordsRequest request) {
+    public SingleIdResponse createSingle(Authentication auth, @RequestBody @Valid SingleRunnerRecordsRequest request) {
         final String runnerId = auth.getName();
         return singleService.create(runnerId, request);
     }

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/single/controller/SingleController.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/single/controller/SingleController.java
@@ -1,0 +1,33 @@
+package online.partyrun.partyrunbattleservice.domain.single.controller;
+
+import jakarta.validation.Valid;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunbattleservice.domain.single.dto.SingleIdResponse;
+import online.partyrun.partyrunbattleservice.domain.single.dto.SingleRunnerRecordsRequest;
+import online.partyrun.partyrunbattleservice.domain.single.service.SingleService;
+import online.partyrun.partyrunbattleservice.global.logging.Logging;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+@Logging
+@RestController
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+@RequiredArgsConstructor
+@RequestMapping("singles")
+public class SingleController {
+
+    SingleService singleService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public SingleIdResponse createSingle(Authentication auth, @Valid SingleRunnerRecordsRequest request) {
+        final String runnerId = auth.getName();
+        return singleService.create(runnerId, request);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/single/dto/SingleIdResponse.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/single/dto/SingleIdResponse.java
@@ -1,0 +1,4 @@
+package online.partyrun.partyrunbattleservice.domain.single.dto;
+
+public record SingleIdResponse(String id) {
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/single/dto/SingleRunnerRecordRequest.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/single/dto/SingleRunnerRecordRequest.java
@@ -1,0 +1,13 @@
+package online.partyrun.partyrunbattleservice.domain.single.dto;
+
+import online.partyrun.partyrunbattleservice.domain.runner.entity.record.GpsData;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
+
+import java.time.LocalDateTime;
+
+public record SingleRunnerRecordRequest(double longitude, double latitude, double altitude, LocalDateTime time, double distance) {
+    public RunnerRecord toRunnerRecord() {
+        final GpsData gpsData = GpsData.of(longitude, latitude, altitude, time);
+        return new RunnerRecord(gpsData, distance);
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/single/dto/SingleRunnerRecordsRequest.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/single/dto/SingleRunnerRecordsRequest.java
@@ -1,0 +1,14 @@
+package online.partyrun.partyrunbattleservice.domain.single.dto;
+
+import jakarta.validation.constraints.NotNull;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
+
+import java.util.List;
+
+public record SingleRunnerRecordsRequest(@NotNull List<SingleRunnerRecordRequest> records) {
+    public List<RunnerRecord> toRunnerRecords() {
+        return this.records.stream()
+                .map(SingleRunnerRecordRequest::toRunnerRecord)
+                .toList();
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/single/entity/Single.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/single/entity/Single.java
@@ -1,0 +1,35 @@
+package online.partyrun.partyrunbattleservice.domain.single.entity;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
+import online.partyrun.partyrunbattleservice.domain.single.exception.SingleRunnerRecordEmptyException;
+import org.springframework.data.annotation.Id;
+
+import java.util.List;
+import java.util.Objects;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@FieldDefaults(level = AccessLevel.PRIVATE)
+public class Single {
+
+    @Id
+    String id;
+    String runnerId;
+    List<RunnerRecord> runnerRecords;
+
+    public Single(String runnerId, List<RunnerRecord> runnerRecords) {
+        validateRunnerRecords(runnerRecords);
+        this.runnerId = runnerId;
+        this.runnerRecords = runnerRecords;
+    }
+
+    private void validateRunnerRecords(List<RunnerRecord> runnerRecords) {
+        if (Objects.isNull(runnerRecords) || runnerRecords.isEmpty()) {
+            throw new SingleRunnerRecordEmptyException();
+        }
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/single/exception/SingleRunnerRecordEmptyException.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/single/exception/SingleRunnerRecordEmptyException.java
@@ -1,0 +1,10 @@
+package online.partyrun.partyrunbattleservice.domain.single.exception;
+
+import online.partyrun.partyrunbattleservice.global.exception.BadRequestException;
+
+public class SingleRunnerRecordEmptyException extends BadRequestException {
+
+    public SingleRunnerRecordEmptyException() {
+        super("Single 모드의 Runner 기록은 빈 값일 수 없습니다.");
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/single/repository/SingleRepository.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/single/repository/SingleRepository.java
@@ -1,0 +1,7 @@
+package online.partyrun.partyrunbattleservice.domain.single.repository;
+
+import online.partyrun.partyrunbattleservice.domain.single.entity.Single;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface SingleRepository extends MongoRepository<Single, String> {
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/single/service/SingleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/single/service/SingleService.java
@@ -1,0 +1,26 @@
+package online.partyrun.partyrunbattleservice.domain.single.service;
+
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.experimental.FieldDefaults;
+import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
+import online.partyrun.partyrunbattleservice.domain.single.dto.SingleIdResponse;
+import online.partyrun.partyrunbattleservice.domain.single.dto.SingleRunnerRecordsRequest;
+import online.partyrun.partyrunbattleservice.domain.single.entity.Single;
+import online.partyrun.partyrunbattleservice.domain.single.repository.SingleRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@FieldDefaults(level = AccessLevel.PRIVATE, makeFinal = true)
+public class SingleService {
+    SingleRepository singleRepository;
+
+    public SingleIdResponse create(String runnerId, SingleRunnerRecordsRequest request) {
+        final List<RunnerRecord> records = request.toRunnerRecords();
+        final Single newSingleRecord = singleRepository.save(new Single(runnerId, records));
+        return new SingleIdResponse(newSingleRecord.getId());
+    }
+}

--- a/src/main/java/online/partyrun/partyrunbattleservice/global/controller/HttpControllerAdvice.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/global/controller/HttpControllerAdvice.java
@@ -1,4 +1,4 @@
-package online.partyrun.partyrunbattleservice.domain.battle.controller;
+package online.partyrun.partyrunbattleservice.global.controller;
 
 import lombok.AccessLevel;
 import lombok.experimental.FieldDefaults;
@@ -48,7 +48,7 @@ public class HttpControllerAdvice {
                         .map(error -> String.format("%s: %s", ((FieldError) error).getField(), error.getDefaultMessage()))
                         .collect(Collectors.joining(", "));
 
-        log.warn("{} {}",EXCEPTION_MESSAGE, message);
+        log.warn("{} {}", EXCEPTION_MESSAGE, message);
         return new ExceptionResponse(BAD_REQUEST_MESSAGE);
     }
 

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/single/controller/SingleControllerTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/single/controller/SingleControllerTest.java
@@ -1,0 +1,72 @@
+package online.partyrun.partyrunbattleservice.domain.single.controller;
+
+import online.partyrun.partyrunbattleservice.domain.single.dto.SingleIdResponse;
+import online.partyrun.partyrunbattleservice.domain.single.dto.SingleRunnerRecordRequest;
+import online.partyrun.partyrunbattleservice.domain.single.dto.SingleRunnerRecordsRequest;
+import online.partyrun.partyrunbattleservice.domain.single.service.SingleService;
+import online.partyrun.testmanager.docs.RestControllerTest;
+import org.junit.jupiter.api.*;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.ResultActions;
+
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SingleController.class)
+@DisplayName("SingleController")
+class SingleControllerTest extends RestControllerTest {
+
+    private static final String SINGLE_URL = "/singles";
+
+    @MockBean
+    SingleService singleService;
+
+    LocalDateTime now = LocalDateTime.now();
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class 싱글을_생성할_때 {
+        @Nested
+        @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+        class 러너의_기록이_주어지면 {
+
+            @Test
+            @DisplayName("싱글을_생성한다")
+            void createSingle() throws Exception {
+                SingleRunnerRecordsRequest request = new SingleRunnerRecordsRequest(
+                        List.of(
+                                new SingleRunnerRecordRequest(0, 0, 0, now, 0),
+                                new SingleRunnerRecordRequest(0.0001, 0.0001, 0.0001, now, 1)
+                        )
+                );
+                final SingleIdResponse response = new SingleIdResponse("single id");
+                given(singleService.create("defaultUser", request)).willReturn(response);
+
+                final ResultActions actions =
+                        mockMvc.perform(
+                                post(SINGLE_URL)
+                                        .with(csrf())
+                                        .header(
+                                                "Authorization",
+                                                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c")
+                                        .contentType(MediaType.APPLICATION_JSON)
+                                        .characterEncoding(StandardCharsets.UTF_8)
+                                        .content(toRequestBody(request)));
+
+                actions.andExpect(status().isCreated())
+                        .andExpect(content().json(toRequestBody(response)));
+
+                setPrintDocs(actions, "create single");
+            }
+        }
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/single/entity/SingleTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/single/entity/SingleTest.java
@@ -1,0 +1,31 @@
+package online.partyrun.partyrunbattleservice.domain.single.entity;
+
+import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
+import online.partyrun.partyrunbattleservice.domain.single.exception.SingleRunnerRecordEmptyException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DisplayName("Single")
+class SingleTest {
+
+    @Nested
+    @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
+    class Single_기록을_생성할_때 {
+
+        @DisplayName("달린 기록이 비었다면 예외를 던진다.")
+        @NullAndEmptySource
+        @ParameterizedTest
+        void throwException(List<RunnerRecord> records) {
+            assertThatThrownBy(() -> new Single("runnerId", records))
+                    .isInstanceOf(SingleRunnerRecordEmptyException.class);
+        }
+    }
+}

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/single/service/SingleServiceTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/single/service/SingleServiceTest.java
@@ -1,0 +1,43 @@
+package online.partyrun.partyrunbattleservice.domain.single.service;
+
+import online.partyrun.partyrunbattleservice.domain.single.dto.SingleIdResponse;
+import online.partyrun.partyrunbattleservice.domain.single.dto.SingleRunnerRecordRequest;
+import online.partyrun.partyrunbattleservice.domain.single.dto.SingleRunnerRecordsRequest;
+import online.partyrun.partyrunbattleservice.domain.single.repository.SingleRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@DisplayName("SingleService")
+class SingleServiceTest {
+
+    @Autowired
+    SingleService singleService;
+    @Autowired
+    SingleRepository singleRepository;
+    String runnerId = "박성우";
+    LocalDateTime now = LocalDateTime.now();
+
+    @Test
+    @DisplayName("싱글 기록을 생성할 수 있다.")
+    void create() {
+        final SingleIdResponse response = singleService.create(
+                runnerId,
+                new SingleRunnerRecordsRequest(
+                        List.of(
+                                new SingleRunnerRecordRequest(0, 0, 0, now, 0),
+                                new SingleRunnerRecordRequest(0.0001, 0.0001, 0.0001, now, 1)
+                        )
+                )
+        );
+
+        assertThat(response.id()).isNotBlank();
+    }
+}


### PR DESCRIPTION
## 변경 사항
싱글 모드의 데이터를 저장하는 API를 만들었습니다.
싱글 데이터에 관한 검증 로직을 거의 추가하지 않았습니다.

1. 안드로이드 측에서 이미 검증을 하고 보내는 데이터이므로
2. 싱글 모드는 클라이언트 측에서 일시 정지, 재시작 등이 존재하므로 검증을 하기에 어려움