### PR TITLE
refactor : SingleRunnerRecordsRequest 메서드명 변경

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/single/dto/SingleRunnerRecordsRequest.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/single/dto/SingleRunnerRecordsRequest.java
@@ -6,13 +6,15 @@ import online.partyrun.partyrunbattleservice.domain.single.entity.RunningTime;
 
 import java.util.List;
 
-public record SingleRunnerRecordsRequest(@NotNull RunningTimeRequest runningTime, @NotNull List<SingleRunnerRecordRequest> records) {
+public record SingleRunnerRecordsRequest(
+        @NotNull RunningTimeRequest runningTime,
+        @NotNull List<SingleRunnerRecordRequest> records) {
 
     public RunningTime getRunningTime() {
         return runningTime.toRunningTime();
     }
 
-    public List<RunnerRecord> getRunnerRecords() {
+    public List<RunnerRecord> runnerRecords() {
         return this.records.stream()
                 .map(SingleRunnerRecordRequest::toRunnerRecord)
                 .toList();

--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/single/service/SingleService.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/single/service/SingleService.java
@@ -21,7 +21,7 @@ public class SingleService {
 
     public SingleIdResponse create(String runnerId, SingleRunnerRecordsRequest request) {
         final RunningTime runningTime = request.getRunningTime();
-        final List<RunnerRecord> records = request.getRunnerRecords();
+        final List<RunnerRecord> records = request.runnerRecords();
         final Single newSingleRecord = singleRepository.save(new Single(runnerId, runningTime, records));
         return new SingleIdResponse(newSingleRecord.getId());
     }

--- a/src/test/java/online/partyrun/partyrunbattleservice/domain/single/dto/SingleRunnerRecordsRequestTest.java
+++ b/src/test/java/online/partyrun/partyrunbattleservice/domain/single/dto/SingleRunnerRecordsRequestTest.java
@@ -1,0 +1,32 @@
+package online.partyrun.partyrunbattleservice.domain.single.dto;
+
+import online.partyrun.partyrunbattleservice.domain.runner.entity.record.RunnerRecord;
+import org.junit.jupiter.api.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+
+@DisplayName("SingleRunnerRecordsRequest")
+class SingleRunnerRecordsRequestTest {
+
+    @Test
+    @DisplayName("records에서 runnerRecords를 가져온다")
+    void getRunnerRecords() {
+        LocalDateTime now = LocalDateTime.now();
+        final List<SingleRunnerRecordRequest> singleRunnerRecords = List.of(
+                new SingleRunnerRecordRequest(0, 0, 0, now, 0),
+                new SingleRunnerRecordRequest(0.0001, 0.0001, 0.0001, now, 1)
+        );
+        SingleRunnerRecordsRequest request = new SingleRunnerRecordsRequest(
+                new RunningTimeRequest(0,0,1),
+                singleRunnerRecords
+        );
+        final List<RunnerRecord> runnerRecords = request.runnerRecords();
+        assertThat(runnerRecords).hasSize(singleRunnerRecords.size());
+    }
+}


### PR DESCRIPTION
기존에 : SingleRunnerRecordsRequest parse 시에 문제가 발생했습니다.
test코드에서 request body를 확인해보니 RunnerRecords도 같이 파싱하는 것을 확인했습니다.
따라서 기존 메서드에서 get 부분을 제거하고, record 스타일에 맞게 runnerRecords()로 변경하였습니다. 변경 이후에는 테스트를 통과하는 것을 확인할 수 있었습니다.
