### PR TITLE
기록이 없는 경우 빈 기록 반환

### DIFF
--- a/src/main/java/online/partyrun/partyrunbattleservice/domain/mypage/dto/MyPageHistoryResponse.java
+++ b/src/main/java/online/partyrun/partyrunbattleservice/domain/mypage/dto/MyPageHistoryResponse.java
@@ -3,11 +3,17 @@ package online.partyrun.partyrunbattleservice.domain.mypage.dto;
 import online.partyrun.partyrunbattleservice.domain.battle.entity.Battle;
 import online.partyrun.partyrunbattleservice.domain.single.entity.Single;
 
+import java.util.Collections;
 import java.util.List;
 
 public record MyPageHistoryResponse(List<MyPageRunningResponse> history) {
+    private static final MyPageHistoryResponse EMPTY_HISTORY = new MyPageHistoryResponse(Collections.emptyList());
 
     public static MyPageHistoryResponse ofBattles(List<Battle> battles, String memberId) {
+        if (battles.isEmpty()) {
+            return EMPTY_HISTORY;
+        }
+
         return new MyPageHistoryResponse(
                 battles.stream()
                         .map(battle -> MyPageRunningResponse.of(battle, memberId))
@@ -16,6 +22,9 @@ public record MyPageHistoryResponse(List<MyPageRunningResponse> history) {
     }
 
     public static MyPageHistoryResponse ofSingle(List<Single> singles) {
+        if (singles.isEmpty()) {
+            return EMPTY_HISTORY;
+        }
         return new MyPageHistoryResponse(
                 singles.stream()
                         .map(MyPageRunningResponse::from)


### PR DESCRIPTION
## 변경 사항
배틀이나 싱글의 기록이 없는 경우, 빈 기록을 반환해야합니다.
이전까지는 기록이 없는 경우 에러가 발생하였습니다.
